### PR TITLE
Allow multiple worksheet defs per file

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -110,6 +110,26 @@ var (
 	pString = newTokenPattern("string", "\".*\"")
 )
 
+func (p *parser) parseWorksheets() (map[string]*tWorksheet, error) {
+	wsDefs := make(map[string]*tWorksheet)
+
+	for p.peek() == "worksheet" { // TODO: jjw: use actual token
+		def, err := p.parseWorksheet()
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := wsDefs[def.name]; exists {
+			return nil, fmt.Errorf("multiple worksheets with name %s", def.name)
+		}
+		wsDefs[def.name] = def
+	}
+	if len(wsDefs) == 0 {
+		return nil, fmt.Errorf("no worksheets defined")
+	}
+
+	return wsDefs, nil
+}
+
 func (p *parser) parseWorksheet() (*tWorksheet, error) {
 	// initialize tWorksheet
 	ws := tWorksheet{

--- a/parser.go
+++ b/parser.go
@@ -113,7 +113,7 @@ var (
 func (p *parser) parseWorksheets() (map[string]*tWorksheet, error) {
 	wsDefs := make(map[string]*tWorksheet)
 
-	for p.peek() == "worksheet" { // TODO: jjw: use actual token
+	for p.peek() == pWorksheet.name {
 		def, err := p.parseWorksheet()
 		if err != nil {
 			return nil, err

--- a/parser.go
+++ b/parser.go
@@ -317,6 +317,17 @@ func (p *parser) next() string {
 	}
 }
 
+func (p *parser) peekAndCheck(expected *tokenPattern) (string, error) {
+	token := p.peek()
+
+	var err error
+	if !expected.re.MatchString(token) {
+		err = fmt.Errorf("expected %s, found %s", expected.name, token)
+	}
+
+	return token, err
+}
+
 func (p *parser) peek() string {
 	token := p.next()
 	p.toks = append(p.toks, token)

--- a/parser.go
+++ b/parser.go
@@ -317,17 +317,6 @@ func (p *parser) next() string {
 	}
 }
 
-func (p *parser) peekAndCheck(expected *tokenPattern) (string, error) {
-	token := p.peek()
-
-	var err error
-	if !expected.re.MatchString(token) {
-		err = fmt.Errorf("expected %s, found %s", expected.name, token)
-	}
-
-	return token, err
-}
-
 func (p *parser) peek() string {
 	token := p.next()
 	p.toks = append(p.toks, token)

--- a/parser.go
+++ b/parser.go
@@ -113,7 +113,7 @@ var (
 func (p *parser) parseWorksheets() (map[string]*tWorksheet, error) {
 	wsDefs := make(map[string]*tWorksheet)
 
-	for p.peek() == pWorksheet.name {
+	for pWorksheet.re.MatchString(p.peek()) {
 		def, err := p.parseWorksheet()
 		if err != nil {
 			return nil, err

--- a/worksheets.go
+++ b/worksheets.go
@@ -49,19 +49,27 @@ const (
 	IndexVersion = -1
 )
 
-// NewDefinitions parses a worksheet definition, and creates a worksheet
+// NewDefinitions parses a worksheet definition file, and creates a worksheet
 // model from it.
 func NewDefinitions(reader io.Reader) (*Definitions, error) {
-	// TODO(pascal): support reading multiple worksheet definitions in one file
+	wsNameToDef := make(map[string]*tWorksheet)
+
 	p := newParser(reader)
-	def, err := p.parseWorksheet()
-	if err != nil {
-		return nil, err
+
+	// TODO: jjw: move to parser.go as parseWorksheets, then call here
+	for p.peek() == "worksheet" { // TODO: jjw: use tok instead of string
+		def, err := p.parseWorksheet()
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := wsNameToDef[def.name]; exists {
+			return nil, fmt.Errorf("multiple worksheets with name %s", def.name)
+		}
+		wsNameToDef[def.name] = def
 	}
+
 	return &Definitions{
-		defs: map[string]*tWorksheet{
-			def.name: def,
-		},
+		defs: wsNameToDef,
 	}, nil
 }
 

--- a/worksheets.go
+++ b/worksheets.go
@@ -52,24 +52,13 @@ const (
 // NewDefinitions parses a worksheet definition file, and creates a worksheet
 // model from it.
 func NewDefinitions(reader io.Reader) (*Definitions, error) {
-	wsNameToDef := make(map[string]*tWorksheet)
-
 	p := newParser(reader)
-
-	// TODO: jjw: move to parser.go as parseWorksheets, then call here
-	for p.peek() == "worksheet" { // TODO: jjw: use tok instead of string
-		def, err := p.parseWorksheet()
-		if err != nil {
-			return nil, err
-		}
-		if _, exists := wsNameToDef[def.name]; exists {
-			return nil, fmt.Errorf("multiple worksheets with name %s", def.name)
-		}
-		wsNameToDef[def.name] = def
+	wsDefs, err := p.parseWorksheets()
+	if err != nil {
+		return nil, err
 	}
-
 	return &Definitions{
-		defs: wsNameToDef,
+		defs: wsDefs,
 	}, nil
 }
 

--- a/worksheets.go
+++ b/worksheets.go
@@ -53,12 +53,12 @@ const (
 // model from it.
 func NewDefinitions(reader io.Reader) (*Definitions, error) {
 	p := newParser(reader)
-	wsDefs, err := p.parseWorksheets()
+	defs, err := p.parseWorksheets()
 	if err != nil {
 		return nil, err
 	}
 	return &Definitions{
-		defs: wsDefs,
+		defs: defs,
 	}, nil
 }
 

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -47,6 +47,14 @@ func (s *Zuite) TestExample() {
 	require.Equal(s.T(), false, isSet)
 }
 
+func (s *Zuite) TestWorksheetNew_zeroDefs() {
+	_, err := NewDefinitions(strings.NewReader(``))
+	require.Error(s.T(), err)
+
+	_, err = NewDefinitions(strings.NewReader(`not a worksheet`))
+	require.Error(s.T(), err)
+}
+
 func (s *Zuite) TestWorksheetNew_multipleDefs() {
 	wsDefs := `worksheet one {1:name text} worksheet two {1:occupation text}`
 	defs, err := NewDefinitions(strings.NewReader(wsDefs))

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -48,11 +48,16 @@ func (s *Zuite) TestExample() {
 }
 
 func (s *Zuite) TestWorksheetNew_zeroDefs() {
-	_, err := NewDefinitions(strings.NewReader(``))
-	require.Error(s.T(), err)
-
-	_, err = NewDefinitions(strings.NewReader(`not a worksheet`))
-	require.Error(s.T(), err)
+	wsDefs := []string{
+		``,
+		`some text`,
+		`not a worksheet`,
+		`work sheet`,
+	}
+	for _, def := range wsDefs {
+		_, err := NewDefinitions(strings.NewReader(def))
+		require.Error(s.T(), err)
+	}
 }
 
 func (s *Zuite) TestWorksheetNew_multipleDefs() {
@@ -73,7 +78,7 @@ func (s *Zuite) TestWorksheetNew_multipleDefs() {
 	require.False(s.T(), isSet)
 }
 
-func (s *Zuite) TestWorksheetNew_multipleDefsRepeatedName() {
+func (s *Zuite) TestWorksheetNew_multipleDefsSameName() {
 	wsDefs := `worksheet simple {1:name text} worksheet simple {1:occupation text}`
 	_, err := NewDefinitions(strings.NewReader(wsDefs))
 	require.Error(s.T(), err)

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -47,6 +47,30 @@ func (s *Zuite) TestExample() {
 	require.Equal(s.T(), false, isSet)
 }
 
+func (s *Zuite) TestWorksheetNew_multipleDefs() {
+	wsDefs := `worksheet one {1:name text} worksheet two {1:occupation text}`
+	defs, err := NewDefinitions(strings.NewReader(wsDefs))
+	require.NoError(s.T(), err)
+
+	ws, err := defs.NewWorksheet("one")
+	require.NoError(s.T(), err)
+	isSet, err := ws.IsSet("name")
+	require.NoError(s.T(), err)
+	require.False(s.T(), isSet)
+
+	ws, err = defs.NewWorksheet("two")
+	require.NoError(s.T(), err)
+	isSet, err = ws.IsSet("occupation")
+	require.NoError(s.T(), err)
+	require.False(s.T(), isSet)
+}
+
+func (s *Zuite) TestWorksheetNew_multipleDefsRepeatedName() {
+	wsDefs := `worksheet simple {1:name text} worksheet simple {1:occupation text}`
+	_, err := NewDefinitions(strings.NewReader(wsDefs))
+	require.Error(s.T(), err)
+}
+
 func (s *Zuite) TestWorksheetNew_origEmpty() {
 	defs, err := NewDefinitions(strings.NewReader(`worksheet simple {1:name text}`))
 	require.NoError(s.T(), err)


### PR DESCRIPTION
Fixes issue #5. A couple of opinions encoded here:

* Defining more than one worksheet with the same name is a fatal error
* Attempting to parse a file which contains zero worksheet defs is a fatal error

I can see reasons for/against the second, so I'm happy to discuss if you want.

Thanks!