### PR TITLE
db update for undefined fields

### DIFF
--- a/dbstore.go
+++ b/dbstore.go
@@ -192,9 +192,6 @@ func (s *Session) Update(ws *Worksheet) error {
 	if err != nil {
 		return err
 	}
-	if result.RowsAffected != int64(len(diff)) {
-		return fmt.Errorf("unable to update old values")
-	}
 
 	// insert new rValues
 	insert := s.tx.InsertInto("worksheet_values").Columns("*").Blacklist("id")

--- a/dbstore_test.go
+++ b/dbstore_test.go
@@ -173,6 +173,27 @@ func (s *DbZuite) TestUpdate() {
 	require.Empty(s.T(), ws.diff())
 }
 
+func (s *DbZuite) TestUpdateUndefinedField() {
+	ws, err := s.store.defs.NewWorksheet("simple")
+	require.NoError(s.T(), err)
+
+	err = ws.Set("name", NewText("Alice"))
+	require.NoError(s.T(), err)
+
+	s.MustRunTransaction(func(tx *runner.Tx) error {
+		session := s.store.Open(tx)
+		return session.Save(ws)
+	})
+
+	err = ws.Set("age", MustNewValue("73"))
+	require.NoError(s.T(), err)
+
+	s.MustRunTransaction(func(tx *runner.Tx) error {
+		session := s.store.Open(tx)
+		return session.Update(ws)
+	})
+}
+
 func IdAt(s []rValue, index int) int64 {
 	if 0 <= index && index < len(s) {
 		return s[index].Id


### PR DESCRIPTION
Was playing around with this today and ran into issues saving worksheets sometimes, if I saved before setting all the fields, because the `RowsAffected` didn't match the `len(diff)`. Since the `"unable to update old values"` block wasn't tested, I guessed the behavior wasn't critical, and removing it fixes the issues I was having. 