### PR TITLE
Fixing with a temporary fix the go.uuid <> sqlx runner issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,5 +25,8 @@ jobs:
 
       # golang
       - run: go get -v -t -d ./...
+      - run: rm -Rf /go/src/github.com/satori/go.uuid
+      - run: mkdir /go/src/github.com/satori/go.uuid
+      - run: curl https://raw.githubusercontent.com/satori/go.uuid/b061729afc07e77a8aa4fad0a2fd840958f1942a/uuid.go > /go/src/github.com/satori/go.uuid/uuid.go
       - run: go test -v ./...
       - run: go run tools/wstest.go `find features -name '*.feature'`


### PR DESCRIPTION
Recently [1], satori/go.uuid changed the signature of various functions, including NewV4 used by sqlx runner. As a result, sqlx runner does not compile at HEAD anymore. A change was submitted to sqlx runner [2], but meanwhile, to keep our build green, we're forcibly setting the satory/go.uuid version to a specific sha. This approach is chosen over vendoring since the intent of worksheets is to be used as a library in a project which would itself manage vendoring.

[1] https://github.com/satori/go.uuid/commit/0ef6afb2f6cdd6cdaeee3885a95099c63f18fc8c
[2] https://github.com/mgutz/dat/pull/77