### PR TITLE
Exporting worksheets' definitions

### DIFF
--- a/dbstore.go
+++ b/dbstore.go
@@ -250,7 +250,7 @@ func (l *loader) readValue(typ Type, optValue dat.NullString) (Value, error) {
 		slice := newSliceWithIdAndLastRank(t, parts[2], lastRank)
 		l.slicesToHydrate[slice.id] = slice
 		return slice, nil
-	case *tWorksheetType:
+	case *Definition:
 		if !strings.HasPrefix(value, "*:") {
 			return nil, fmt.Errorf("unreadable value for ref %s", value)
 		}

--- a/parser.go
+++ b/parser.go
@@ -75,8 +75,8 @@ var (
 	pNumberWithDot        = newTokenPattern("number", "\\.[0-9]*")
 )
 
-func (p *parser) parseWorksheets() (map[string]*tWorksheet, error) {
-	wsDefs := make(map[string]*tWorksheet)
+func (p *parser) parseWorksheets() (map[string]*Definition, error) {
+	wsDefs := make(map[string]*Definition)
 
 	for p.peek(pWorksheet) {
 		def, err := p.parseWorksheet()
@@ -92,9 +92,8 @@ func (p *parser) parseWorksheets() (map[string]*tWorksheet, error) {
 	return wsDefs, nil
 }
 
-func (p *parser) parseWorksheet() (*tWorksheet, error) {
-	// initialize tWorksheet
-	ws := tWorksheet{
+func (p *parser) parseWorksheet() (*Definition, error) {
+	ws := Definition{
 		fieldsByName:  make(map[string]*tField),
 		fieldsByIndex: make(map[int]*tField),
 	}
@@ -546,7 +545,7 @@ func (p *parser) parseType() (Type, error) {
 			}
 			return &tNumberType{scale}, nil
 		default:
-			return &tWorksheetType{name: name}, nil
+			return &Definition{name: name}, nil
 		}
 
 	case "slice":

--- a/parser_test.go
+++ b/parser_test.go
@@ -20,14 +20,14 @@ import (
 )
 
 func (s *Zuite) TestParser_parseWorksheet() {
-	cases := map[string]func(*tWorksheet){
-		`worksheet simple {}`: func(ws *tWorksheet) {
+	cases := map[string]func(*Definition){
+		`worksheet simple {}`: func(ws *Definition) {
 			require.Equal(s.T(), "simple", ws.name)
 			require.Equal(s.T(), 2+0, len(ws.fields))
 			require.Equal(s.T(), 2+0, len(ws.fieldsByName))
 			require.Equal(s.T(), 2+0, len(ws.fieldsByIndex))
 		},
-		`worksheet simple {42:full_name text}`: func(ws *tWorksheet) {
+		`worksheet simple {42:full_name text}`: func(ws *Definition) {
 			require.Equal(s.T(), "simple", ws.name)
 			require.Equal(s.T(), 2+1, len(ws.fields))
 			require.Equal(s.T(), 2+1, len(ws.fieldsByName))
@@ -40,7 +40,7 @@ func (s *Zuite) TestParser_parseWorksheet() {
 			require.Equal(s.T(), ws.fieldsByName["full_name"], field)
 			require.Equal(s.T(), ws.fieldsByIndex[42], field)
 		},
-		`  worksheet simple {42:full_name text 45:happy bool}`: func(ws *tWorksheet) {
+		`  worksheet simple {42:full_name text 45:happy bool}`: func(ws *Definition) {
 			require.Equal(s.T(), "simple", ws.name)
 			require.Equal(s.T(), 2+2, len(ws.fields))
 
@@ -264,7 +264,7 @@ func (s *Zuite) TestParser_parseType() {
 		`bool`:      &tBoolType{},
 		`number[5]`: &tNumberType{5},
 		`[]bool`:    &tSliceType{&tBoolType{}},
-		`foobar`:    &tWorksheetType{name: "foobar"},
+		`foobar`:    &Definition{name: "foobar"},
 	}
 	for input, expected := range cases {
 		p := newParser(strings.NewReader(input))

--- a/tree.go
+++ b/tree.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 )
 
-type tWorksheet struct {
+type Definition struct {
 	name          string
 	fields        []*tField
 	fieldsByName  map[string]*tField
@@ -27,13 +27,13 @@ type tWorksheet struct {
 	dependents map[int][]int
 }
 
-func (ws *tWorksheet) addField(field *tField) {
-	ws.fields = append(ws.fields, field)
+func (def *Definition) addField(field *tField) {
+	def.fields = append(def.fields, field)
 
 	// Clobbering due to name reuse, or index reuse, is checked by validating
 	// the tree.
-	ws.fieldsByName[field.name] = field
-	ws.fieldsByIndex[field.index] = field
+	def.fieldsByName[field.name] = field
+	def.fieldsByIndex[field.index] = field
 }
 
 type tField struct {
@@ -56,10 +56,6 @@ type tNumberType struct {
 
 type tSliceType struct {
 	elementType Type
-}
-
-type tWorksheetType struct {
-	name string
 }
 
 type tOp string

--- a/types.go
+++ b/types.go
@@ -32,7 +32,7 @@ var _ []Type = []Type{
 	&tBoolType{},
 	&tNumberType{},
 	&tSliceType{},
-	&tWorksheetType{},
+	&Definition{},
 }
 
 func (typ *tUndefinedType) AssignableTo(_ Type) bool {
@@ -79,11 +79,12 @@ func (typ *tSliceType) String() string {
 	return fmt.Sprintf("[]%s", typ.elementType)
 }
 
-func (typ *tWorksheetType) AssignableTo(u Type) bool {
-	other, ok := u.(*tWorksheetType)
-	return ok && typ.name == other.name
+func (def *Definition) AssignableTo(u Type) bool {
+	// Since we do type resolution, pointer equality suffices to
+	// guarantee assignability.
+	return def == u
 }
 
-func (typ *tWorksheetType) String() string {
-	return typ.name
+func (def *Definition) String() string {
+	return def.name
 }

--- a/types_test.go
+++ b/types_test.go
@@ -63,12 +63,12 @@ func (s *Zuite) TestTypeNotAssignableTo() {
 
 func (s *Zuite) TestTypeString() {
 	cases := map[Type]string{
-		&tUndefinedType{}:         "undefined",
-		&tTextType{}:              "text",
-		&tBoolType{}:              "bool",
-		&tNumberType{1}:           "number[1]",
-		&tSliceType{&tBoolType{}}: "[]bool",
-		&tWorksheetType{"simple"}: "simple",
+		&tUndefinedType{}:           "undefined",
+		&tTextType{}:                "text",
+		&tBoolType{}:                "bool",
+		&tNumberType{1}:             "number[1]",
+		&tSliceType{&tBoolType{}}:   "[]bool",
+		&Definition{name: "simple"}: "simple",
 	}
 	for typ, expected := range cases {
 		assert.Equal(s.T(), expected, typ.String(), expected)

--- a/values.go
+++ b/values.go
@@ -390,7 +390,7 @@ func (value *slice) String() string {
 }
 
 func (ws *Worksheet) Type() Type {
-	return &tWorksheetType{ws.def.name}
+	return ws.def
 }
 
 func (ws *Worksheet) Equal(that Value) bool {

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -116,6 +116,40 @@ func (s *Zuite) TestWorksheetNew_origEmpty() {
 	require.Empty(s.T(), ws.orig)
 }
 
+func (s *Zuite) TestWorksheetNew_refTypesMustBeResolved() {
+	defs := MustNewDefinitions(strings.NewReader(`
+		worksheet simple {
+			1:me     simple
+			2:myself simple
+			3:and_i  simple
+			4:not_me even_simpler
+		}
+
+		worksheet even_simpler {
+			5:not_it simple
+		}`))
+	simpleDef := defs.defs["simple"]
+	evenSimplerDef := defs.defs["even_simpler"]
+
+	cases := []struct {
+		parent *Definition
+		field  string
+		child  *Definition
+	}{
+		{simpleDef, "me", simpleDef},
+		{simpleDef, "myself", simpleDef},
+		{simpleDef, "and_i", simpleDef},
+		{simpleDef, "not_me", evenSimplerDef},
+
+		{evenSimplerDef, "not_it", simpleDef},
+	}
+	for _, ex := range cases {
+		assert.True(s.T(), ex.parent.fieldsByName[ex.field].typ == ex.child,
+			"type of field %s.%s should resolve to def of %s",
+			ex.parent, ex.field, ex.child)
+	}
+}
+
 func (s *Zuite) TestWorksheetGet_undefinedIfNoValue() {
 	defs, err := NewDefinitions(strings.NewReader(`worksheet simple {1:name text}`))
 	require.NoError(s.T(), err)


### PR DESCRIPTION
- Making Definition a Type, and exporting it
- Doing type resolution to ensure ws.Type() returns the definition of this worksheet
- And this removes the need to have a tWorksheetType which was kinda ugly anyways, good riddance