### PR TITLE
Being go-ish and requiring explicit return

### DIFF
--- a/computed_by_test.go
+++ b/computed_by_test.go
@@ -275,7 +275,7 @@ func (s *Zuite) TestExternalComputedBy_goodComplicated() {
 func (s *Zuite) TestSimpleExpressionsInWorksheet() {
 	defs, err := NewDefinitions(strings.NewReader(`worksheet simple {
 		1:age number[0]
-		2:age_plus_two number[0] computed_by { age + 2 }
+		2:age_plus_two number[0] computed_by { return age + 2 }
 	}`))
 	require.NoError(s.T(), err)
 
@@ -289,10 +289,10 @@ func (s *Zuite) TestCyclicEditsIfNoIdentCheck() {
 	defs, err := NewDefinitions(strings.NewReader(`worksheet cyclic_edits {
 		1:right bool
 		2:a bool computed_by {
-			b || right
+			return b || right
 		}
 		3:b bool computed_by {
-			a || !right
+			return a || !right
 		}
 	}`))
 	require.NoError(s.T(), err)

--- a/expressions.go
+++ b/expressions.go
@@ -33,6 +33,7 @@ var _ = []expression{
 	&tVar{},
 	&tUnop{},
 	&tBinop{},
+	&tReturn{},
 }
 
 func (e *tExternal) Args() []string {
@@ -207,6 +208,14 @@ func (e *tBinop) Compute(ws *Worksheet) (Value, error) {
 	}
 
 	return result, nil
+}
+
+func (e *tReturn) Args() []string {
+	return e.expr.Args()
+}
+
+func (e *tReturn) Compute(ws *Worksheet) (Value, error) {
+	return e.expr.Compute(ws)
 }
 
 type ePlugin struct {

--- a/features/some_expressions.ws
+++ b/features/some_expressions.ws
@@ -1,12 +1,12 @@
 worksheet some_expressions {
 	1:num number[2]
 	2:num_plus_two number[2] computed_by {
-		num + 2 round down 2
+		return num + 2 round down 2
 	}
 	3:num_more_decimals number[4] computed_by {
-		num round down 4
+		return num round down 4
 	}
 	4:volume_of_sphere_of_num_radius number[4] computed_by {
-		(4 / 3 round down 6 * 3.141593 * num * num * num) round down 4
+		return (4 / 3 round down 6 * 3.141593 * num * num * num) round down 4
 	}
 }

--- a/tree.go
+++ b/tree.go
@@ -101,3 +101,7 @@ func (t *tBinop) String() string {
 type tVar struct {
 	name string
 }
+
+type tReturn struct {
+	expr expression
+}


### PR DESCRIPTION
This is a stepping stone to introducing more statements such as `if`, `for`, `x := expr`, etc. When we do introduce them, we can model them as optionally value producing expressions, and add a `ReturnsValue() bool` func to interrogate whether they do or do not, and require the top-level expression of a `computed_by` to produce a value.