### PR TITLE
Export more types

### DIFF
--- a/dbstore.go
+++ b/dbstore.go
@@ -234,7 +234,7 @@ func (l *loader) readValue(typ Type, optValue dat.NullString) (Value, error) {
 	switch t := typ.(type) {
 	case *tTextType:
 		return NewText(value), nil
-	case *tSliceType:
+	case *SliceType:
 		if !strings.HasPrefix(value, "[:") {
 			return nil, fmt.Errorf("unreadable value for slice %s", value)
 		}

--- a/parser.go
+++ b/parser.go
@@ -550,7 +550,7 @@ func (p *parser) parseType() (Type, error) {
 			return nil, err
 		}
 
-		return &tSliceType{elementType}, nil
+		return &SliceType{elementType}, nil
 
 	default:
 		panic(fmt.Sprintf("unknown choice %s", choice))

--- a/parser.go
+++ b/parser.go
@@ -95,15 +95,15 @@ func (p *parser) parseWorksheets() (map[string]*Definition, error) {
 
 func (p *parser) parseWorksheet() (*Definition, error) {
 	ws := Definition{
-		fieldsByName:  make(map[string]*tField),
-		fieldsByIndex: make(map[int]*tField),
+		fieldsByName:  make(map[string]*Field),
+		fieldsByIndex: make(map[int]*Field),
 	}
-	ws.addField(&tField{
+	ws.addField(&Field{
 		index: IndexId,
 		name:  "id",
 		typ:   &tTextType{},
 	})
-	ws.addField(&tField{
+	ws.addField(&Field{
 		index: IndexVersion,
 		name:  "version",
 		typ:   &tNumberType{},
@@ -141,7 +141,7 @@ func (p *parser) parseWorksheet() (*Definition, error) {
 	return &ws, nil
 }
 
-func (p *parser) parseField() (*tField, error) {
+func (p *parser) parseField() (*Field, error) {
 	sIndex, err := p.nextAndCheck(pIndex)
 	if err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func (p *parser) parseField() (*tField, error) {
 		}
 	}
 
-	f := &tField{
+	f := &Field{
 		index:      index,
 		name:       name,
 		typ:        typ,

--- a/parser_test.go
+++ b/parser_test.go
@@ -271,7 +271,7 @@ func (s *Zuite) TestParser_parseType() {
 		`text`:      &tTextType{},
 		`bool`:      &tBoolType{},
 		`number[5]`: &tNumberType{5},
-		`[]bool`:    &tSliceType{&tBoolType{}},
+		`[]bool`:    &SliceType{&tBoolType{}},
 		`foobar`:    &Definition{name: "foobar"},
 	}
 	for input, expected := range cases {

--- a/slices_test.go
+++ b/slices_test.go
@@ -107,7 +107,7 @@ func (s *Zuite) TestSliceErrors_delOnNonSliceFailsEvenIfUndefined() {
 }
 
 func (s *Zuite) TestSliceOps() {
-	slice1 := newSliceWithIdAndLastRank(&tSliceType{&tTextType{}}, "a-cool-id", 0)
+	slice1 := newSliceWithIdAndLastRank(&SliceType{&tTextType{}}, "a-cool-id", 0)
 
 	require.Len(s.T(), slice1.elements, 0)
 
@@ -261,7 +261,7 @@ func (s *DbZuite) TestSliceLoad() {
 	slice := fresh.data[42].(*slice)
 	require.Equal(s.T(), theSliceId, slice.id)
 	require.Equal(s.T(), 4, slice.lastRank)
-	require.Equal(s.T(), &tSliceType{&tTextType{}}, slice.typ)
+	require.Equal(s.T(), &SliceType{&tTextType{}}, slice.typ)
 }
 
 func (s *DbZuite) TestSliceUpdate_appendsThenDelThenAppendAgain() {

--- a/tree.go
+++ b/tree.go
@@ -18,16 +18,16 @@ import (
 
 type Definition struct {
 	name          string
-	fields        []*tField
-	fieldsByName  map[string]*tField
-	fieldsByIndex map[int]*tField
+	fields        []*Field
+	fieldsByName  map[string]*Field
+	fieldsByIndex map[int]*Field
 
 	// derived values handling
 	externals  map[int]ComputedBy
 	dependents map[int][]int
 }
 
-func (def *Definition) addField(field *tField) {
+func (def *Definition) addField(field *Field) {
 	def.fields = append(def.fields, field)
 
 	// Clobbering due to name reuse, or index reuse, is checked by validating
@@ -36,12 +36,20 @@ func (def *Definition) addField(field *tField) {
 	def.fieldsByIndex[field.index] = field
 }
 
-type tField struct {
+type Field struct {
 	index      int
 	name       string
 	typ        Type
 	computedBy expression
 	// also need constrainedBy *tExpression
+}
+
+func (f *Field) Type() Type {
+	return f.typ
+}
+
+func (f *Field) Name() string {
+	return f.name
 }
 
 type tUndefinedType struct{}

--- a/tree.go
+++ b/tree.go
@@ -62,14 +62,6 @@ type tNumberType struct {
 	scale int
 }
 
-type SliceType struct {
-	elementType Type
-}
-
-func (s *SliceType) ElementType() Type {
-	return s.elementType
-}
-
 type tOp string
 
 const (

--- a/tree.go
+++ b/tree.go
@@ -62,8 +62,12 @@ type tNumberType struct {
 	scale int
 }
 
-type tSliceType struct {
+type SliceType struct {
 	elementType Type
+}
+
+func (s *SliceType) ElementType() Type {
+	return s.elementType
 }
 
 type tOp string

--- a/types.go
+++ b/types.go
@@ -93,10 +93,6 @@ func (def *Definition) FieldByName(name string) *Field {
 	return def.fieldsByName[name]
 }
 
-func (def *Definition) FieldNames() []string {
-	fieldNames := []string{}
-	for fieldName, _ := range def.fieldsByName {
-		fieldNames = append(fieldNames, fieldName)
-	}
-	return fieldNames
+func (def *Definition) Fields() []*Field {
+	return def.fields
 }

--- a/types.go
+++ b/types.go
@@ -31,7 +31,7 @@ var _ []Type = []Type{
 	&tTextType{},
 	&tBoolType{},
 	&tNumberType{},
-	&tSliceType{},
+	&SliceType{},
 	&Definition{},
 }
 
@@ -70,12 +70,12 @@ func (typ *tNumberType) String() string {
 	return fmt.Sprintf("number[%d]", typ.scale)
 }
 
-func (typ *tSliceType) AssignableTo(u Type) bool {
-	other, ok := u.(*tSliceType)
+func (typ *SliceType) AssignableTo(u Type) bool {
+	other, ok := u.(*SliceType)
 	return ok && typ.elementType.AssignableTo(other.elementType)
 }
 
-func (typ *tSliceType) String() string {
+func (typ *SliceType) String() string {
 	return fmt.Sprintf("[]%s", typ.elementType)
 }
 

--- a/types.go
+++ b/types.go
@@ -35,6 +35,14 @@ var _ []Type = []Type{
 	&Definition{},
 }
 
+type SliceType struct {
+	elementType Type
+}
+
+func (s *SliceType) ElementType() Type {
+	return s.elementType
+}
+
 func (typ *tUndefinedType) AssignableTo(_ Type) bool {
 	return true
 }

--- a/types.go
+++ b/types.go
@@ -89,6 +89,10 @@ func (def *Definition) String() string {
 	return def.name
 }
 
+func (def *Definition) FieldByName(name string) *Field {
+	return def.fieldsByName[name]
+}
+
 func (def *Definition) FieldNames() []string {
 	fieldNames := []string{}
 	for fieldName, _ := range def.fieldsByName {

--- a/types_test.go
+++ b/types_test.go
@@ -67,7 +67,7 @@ func (s *Zuite) TestTypeString() {
 		&tTextType{}:                "text",
 		&tBoolType{}:                "bool",
 		&tNumberType{1}:             "number[1]",
-		&tSliceType{&tBoolType{}}:   "[]bool",
+		&SliceType{&tBoolType{}}:    "[]bool",
 		&Definition{name: "simple"}: "simple",
 	}
 	for typ, expected := range cases {

--- a/types_test.go
+++ b/types_test.go
@@ -13,6 +13,8 @@
 package worksheets
 
 import (
+	"strings"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,5 +74,36 @@ func (s *Zuite) TestTypeString() {
 	}
 	for typ, expected := range cases {
 		assert.Equal(s.T(), expected, typ.String(), expected)
+	}
+}
+
+func (s *Zuite) TestWorksheetDefinition_Fields() {
+	defs, err := NewDefinitions(strings.NewReader(`worksheet simple {1:name text}`))
+	require.NoError(s.T(), err)
+
+	ws := defs.MustNewWorksheet("simple")
+
+	fields := ws.Type().(*Definition).Fields()
+	require.Len(s.T(), fields, 3)
+
+	expectedFields := []*Field{
+		{
+			index: 1,
+			name:  "name",
+			typ:   &tTextType{},
+		},
+		{
+			index: -2,
+			name:  "id",
+			typ:   &tTextType{},
+		},
+		{
+			index: -1,
+			name:  "version",
+			typ:   &tNumberType{},
+		},
+	}
+	for _, field := range expectedFields {
+		require.Contains(s.T(), fields, field)
 	}
 }

--- a/values.go
+++ b/values.go
@@ -306,18 +306,18 @@ func (el sliceElement) String() string {
 type slice struct {
 	id       string
 	lastRank int
-	typ      *tSliceType
+	typ      *SliceType
 	elements []sliceElement
 }
 
-func newSlice(typ *tSliceType) *slice {
+func newSlice(typ *SliceType) *slice {
 	return &slice{
 		id:  uuid.NewV4().String(),
 		typ: typ,
 	}
 }
 
-func newSliceWithIdAndLastRank(typ *tSliceType, id string, lastRank int) *slice {
+func newSliceWithIdAndLastRank(typ *SliceType, id string, lastRank int) *slice {
 	return &slice{
 		id:       id,
 		typ:      typ,

--- a/worksheets.go
+++ b/worksheets.go
@@ -156,11 +156,11 @@ func resolveRefTypes(niceFieldName string, defs map[string]*Definition, locus in
 			}
 			field.typ = refDef
 		}
-		if _, ok := field.typ.(*tSliceType); ok {
+		if _, ok := field.typ.(*SliceType); ok {
 			return resolveRefTypes(niceFieldName, defs, field.typ)
 		}
-	case *tSliceType:
-		sliceType := locus.(*tSliceType)
+	case *SliceType:
+		sliceType := locus.(*SliceType)
 		if refTyp, ok := sliceType.elementType.(*Definition); ok {
 			refDef, ok := defs[refTyp.name]
 			if !ok {
@@ -316,7 +316,7 @@ func (ws *Worksheet) Set(name string, value Value) error {
 		return fmt.Errorf("cannot assign to computed field %s", name)
 	}
 
-	if _, ok := field.typ.(*tSliceType); ok {
+	if _, ok := field.typ.(*SliceType); ok {
 		return fmt.Errorf("Set on slice field %s, use Append, or Del", name)
 	}
 
@@ -372,7 +372,7 @@ func (ws *Worksheet) MustUnset(name string) {
 
 func (ws *Worksheet) Unset(name string) error {
 	if field, ok := ws.def.fieldsByName[name]; ok {
-		if _, ok := field.typ.(*tSliceType); ok {
+		if _, ok := field.typ.(*SliceType); ok {
 			return fmt.Errorf("Unset on slice field names, must use Del")
 		}
 	}
@@ -438,7 +438,7 @@ func (ws *Worksheet) getSlice(name string) (*Field, *slice, error) {
 		return nil, nil, err
 	}
 
-	if _, ok := field.typ.(*tSliceType); !ok {
+	if _, ok := field.typ.(*SliceType); !ok {
 		return field, nil, fmt.Errorf("GetSlice on non-slice field %s, use Get", name)
 	}
 
@@ -457,7 +457,7 @@ func (ws *Worksheet) Get(name string) (Value, error) {
 		return nil, err
 	}
 
-	if _, ok := field.typ.(*tSliceType); ok {
+	if _, ok := field.typ.(*SliceType); ok {
 		return nil, fmt.Errorf("Get on slice field %s, use GetSlice", name)
 	}
 
@@ -495,7 +495,7 @@ func (ws *Worksheet) Append(name string, element Value) error {
 	}
 	index := field.index
 
-	sliceType, ok := field.typ.(*tSliceType)
+	sliceType, ok := field.typ.(*SliceType)
 	if !ok {
 		return fmt.Errorf("Append on non-slice field %s", name)
 	}
@@ -528,7 +528,7 @@ func (ws *Worksheet) Del(name string, index int) error {
 	field, slice, err := ws.getSlice(name)
 	if err != nil {
 		if field != nil {
-			if _, ok := field.typ.(*tSliceType); !ok {
+			if _, ok := field.typ.(*SliceType); !ok {
 				return fmt.Errorf("Del on non-slice field %s", name)
 			}
 		}

--- a/worksheets.go
+++ b/worksheets.go
@@ -147,8 +147,8 @@ func NewDefinitions(reader io.Reader, opts ...Options) (*Definitions, error) {
 
 func resolveRefTypes(niceFieldName string, defs map[string]*Definition, locus interface{}) error {
 	switch locus.(type) {
-	case *tField:
-		field := locus.(*tField)
+	case *Field:
+		field := locus.(*Field)
 		if refTyp, ok := field.typ.(*Definition); ok {
 			refDef, ok := defs[refTyp.name]
 			if !ok {
@@ -324,7 +324,7 @@ func (ws *Worksheet) Set(name string, value Value) error {
 	return err
 }
 
-func (ws *Worksheet) set(field *tField, value Value) error {
+func (ws *Worksheet) set(field *Field, value Value) error {
 	index := field.index
 
 	// ident
@@ -432,7 +432,7 @@ func (ws *Worksheet) GetSlice(name string) ([]Value, error) {
 	return values, nil
 }
 
-func (ws *Worksheet) getSlice(name string) (*tField, *slice, error) {
+func (ws *Worksheet) getSlice(name string) (*Field, *slice, error) {
 	field, value, err := ws.get(name)
 	if err != nil {
 		return nil, nil, err
@@ -464,7 +464,7 @@ func (ws *Worksheet) Get(name string) (Value, error) {
 	return value, err
 }
 
-func (ws *Worksheet) get(name string) (*tField, Value, error) {
+func (ws *Worksheet) get(name string) (*Field, Value, error) {
 	// lookup field by name
 	field, ok := ws.def.fieldsByName[name]
 	if !ok {

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -342,18 +342,3 @@ func toSlice(data map[int]Value) *slice {
 	}
 	return slice
 }
-
-func (s *Zuite) TestWorksheetDefinition_FieldNames() {
-	defs, err := NewDefinitions(strings.NewReader(`worksheet simple {1:name text}`))
-	require.NoError(s.T(), err)
-
-	ws := defs.MustNewWorksheet("simple")
-
-	fields := ws.Type().(*Definition).FieldNames()
-	require.Len(s.T(), fields, 3)
-
-	expectedFields := []string{"name", "id", "version"}
-	for _, field := range expectedFields {
-		require.Contains(s.T(), fields, field)
-	}
-}

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -167,11 +167,11 @@ func (s *Zuite) TestWorksheetNew_refTypesMustBeResolved() {
 	}
 
 	// slices
-	manySimplesTyp := refsInSlicesDef.fieldsByName["many_simples"].typ.(*tSliceType)
+	manySimplesTyp := refsInSlicesDef.fieldsByName["many_simples"].typ.(*SliceType)
 	assert.True(s.T(), manySimplesTyp.elementType == simpleDef)
 
-	manySimplersTyp := refsInSlicesDef.fieldsByName["many_simplers"].typ.(*tSliceType)
-	manySimplersElemTyp := manySimplersTyp.elementType.(*tSliceType)
+	manySimplersTyp := refsInSlicesDef.fieldsByName["many_simplers"].typ.(*SliceType)
+	manySimplersElemTyp := manySimplersTyp.elementType.(*SliceType)
 	assert.True(s.T(), manySimplersElemTyp.elementType == evenSimplerDef)
 }
 


### PR DESCRIPTION
Changed `Field` and `SliceType` to be exported, so we can figure out field types based on the definition (and know e.g. if we need to `Set` a value or `Append` it).