### PR TITLE
Capturing the 'signoff pattern' (and fixes to update to ensure it works)

### DIFF
--- a/expressions.go
+++ b/expressions.go
@@ -168,22 +168,22 @@ func (e *tBinop) Compute(ws *Worksheet) (Value, error) {
 	}
 
 	// numerical operations
-	nLeft, ok := left.(*Number)
-	if !ok {
-		return nil, fmt.Errorf("op on non-number")
-	}
-
 	if _, ok := left.(*Undefined); ok {
 		return left, nil
 	}
 
-	nRight, ok := right.(*Number)
+	nLeft, ok := left.(*Number)
 	if !ok {
 		return nil, fmt.Errorf("op on non-number")
 	}
 
 	if _, ok := right.(*Undefined); ok {
 		return right, nil
+	}
+
+	nRight, ok := right.(*Number)
+	if !ok {
+		return nil, fmt.Errorf("op on non-number")
 	}
 
 	var result *Number


### PR DESCRIPTION
By capturing the version at which sign-off is given, we can have a computed field automatically indicating whether a worksheet was signed-off or not.

To make this work, the update must set the new version and trigger downstream calculations -- whereas before we overlooked that and did a straight change in the internal data table. This also means that if a failure occurs, we must properly rollback the version change, and do so consistently on every exit point of the update function. To this end, using a deferred func to rollback, which gets turned off if-and-only-if we know the update will succeed.