### PR TITLE
Implementing StructScan

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -590,7 +590,7 @@ func (p *parser) parseLiteral() (Value, error) {
 			token = token + strings.Replace(addToken, "_", "", -1)
 		}
 		dot := strings.Index(token, ".")
-		value, err := strconv.ParseInt(strings.Replace(token, ".", "", 1), 10, 64)
+		value, err := strconv.ParseInt("-"+strings.Replace(token, ".", "", 1), 10, 64)
 		if err != nil {
 			return nil, err
 		}
@@ -600,7 +600,7 @@ func (p *parser) parseLiteral() (Value, error) {
 		} else {
 			scale = len(token) - dot - 1
 		}
-		if negNumber {
+		if !negNumber {
 			value = -value
 		}
 		return &Number{value, &NumberType{scale}}, nil


### PR DESCRIPTION
Introducing a `StructScan` func to export worksheets to Golang structs. This is meant to simplify accessing worksheet data, when it is time for it -- the data -- to leave it's comfortable home of sheets.

Some details about how this works, and how it makes things simpler:

- You can define a struct with `ws:"field_name"` tag on its fields, and `StructScan` will export the worksheet fields matching into the Golang struct. For instance:

```var data struct {
    Name   string  `ws:"full_name"`
    Age    int     `ws:"age"`
    Phone  *string `ws:"phone_number"`
}
```

- Since all fields in a worksheet are optional, pointer receivers are also supported. For instance, in the example above, we are indicating that `Name` and `Age` must be set for `StructScan` to succeed, whereas `Phone` is expected to be optionally set.