### PR TITLE
Defer autorollback before fn call in case fn panics

### DIFF
--- a/dbutil.go
+++ b/dbutil.go
@@ -12,7 +12,9 @@
 
 package worksheets
 
-import runner "github.com/helloeave/dat/sqlx-runner"
+import (
+	"gopkg.in/mgutz/dat.v2/sqlx-runner"
+)
 
 func RunTransaction(db *runner.DB, fn func(tx *runner.Tx) error) error {
 	tx, err := db.Begin()

--- a/dbutil.go
+++ b/dbutil.go
@@ -12,19 +12,17 @@
 
 package worksheets
 
-import (
-	"gopkg.in/mgutz/dat.v2/sqlx-runner"
-)
+import runner "github.com/helloeave/dat/sqlx-runner"
 
 func RunTransaction(db *runner.DB, fn func(tx *runner.Tx) error) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return err
 	}
+	defer tx.AutoRollback()
 
 	err = fn(tx)
 	if err != nil {
-		defer tx.Rollback()
 		return err
 	}
 


### PR DESCRIPTION
@lgonzalez-silen 's observation on `neatdb` `RunTransaction` while reviewing https://phabricator.helloeave.com/D986. Same code is here. If `fn` panics, rather than returning an error, currently, `Rollback ` won't be called. 