### PR TITLE
Cross worksheet updates, a start

### DIFF
--- a/computed_by_test.go
+++ b/computed_by_test.go
@@ -350,8 +350,8 @@ func (s *Zuite) TestComputedBy_simpleCrossWsParentPointers() {
 	require.True(s.T(), child.parents["parent"][2]["parent-id"] == parent)
 
 	parent.MustUnset("child")
-	require.Len(s.T(), child.parents, 1)
-	require.Len(s.T(), child.parents["parent"], 1)
+	require.Len(s.T(), child.parents, 0)
+	require.Len(s.T(), child.parents["parent"], 0)
 	require.Len(s.T(), child.parents["parent"][2], 0)
 }
 
@@ -443,8 +443,8 @@ func (s *Zuite) TestComputedBy_crossWsThroughSliceParentPointers() {
 	require.True(s.T(), child2.parents["parent"][2]["parent-id"] == parent)
 
 	parent.Del("children", 0)
-	require.Len(s.T(), child1.parents, 1)
-	require.Len(s.T(), child1.parents["parent"], 1)
+	require.Len(s.T(), child1.parents, 0)
+	require.Len(s.T(), child1.parents["parent"], 0)
 	require.Len(s.T(), child1.parents["parent"][2], 0)
 	require.Len(s.T(), child2.parents, 1)
 	require.Len(s.T(), child2.parents["parent"], 1)
@@ -452,11 +452,11 @@ func (s *Zuite) TestComputedBy_crossWsThroughSliceParentPointers() {
 	require.True(s.T(), child2.parents["parent"][2]["parent-id"] == parent)
 
 	parent.Del("children", 0)
-	require.Len(s.T(), child1.parents, 1)
-	require.Len(s.T(), child1.parents["parent"], 1)
+	require.Len(s.T(), child1.parents, 0)
+	require.Len(s.T(), child1.parents["parent"], 0)
 	require.Len(s.T(), child1.parents["parent"][2], 0)
-	require.Len(s.T(), child2.parents, 1)
-	require.Len(s.T(), child2.parents["parent"], 1)
+	require.Len(s.T(), child2.parents, 0)
+	require.Len(s.T(), child2.parents["parent"], 0)
 	require.Len(s.T(), child2.parents["parent"][2], 0)
 }
 

--- a/constrained_by_test.go
+++ b/constrained_by_test.go
@@ -1,3 +1,15 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package worksheets
 
 import (

--- a/expressions.go
+++ b/expressions.go
@@ -14,6 +14,7 @@ package worksheets
 
 import (
 	"fmt"
+	"strings"
 )
 
 type expression interface {
@@ -30,7 +31,7 @@ var _ = []expression{
 
 	&tExternal{},
 	&ePlugin{},
-	&tVar{},
+	tSelector(nil),
 	&tUnop{},
 	&tBinop{},
 	&tReturn{},
@@ -76,12 +77,13 @@ func (e *Bool) Compute(ws *Worksheet) (Value, error) {
 	return e, nil
 }
 
-func (e *tVar) Args() []string {
-	return []string{e.name}
+func (e tSelector) Args() []string {
+	return []string{strings.Join([]string(e), ".")}
 }
 
-func (e *tVar) Compute(ws *Worksheet) (Value, error) {
-	return ws.Get(e.name)
+func (e tSelector) Compute(ws *Worksheet) (Value, error) {
+	// TODO(pascal): fix this!
+	return ws.Get(e[0])
 }
 
 func (e *tUnop) Args() []string {

--- a/expressions.go
+++ b/expressions.go
@@ -82,8 +82,25 @@ func (e tSelector) Args() []string {
 }
 
 func (e tSelector) Compute(ws *Worksheet) (Value, error) {
-	// TODO(pascal): fix this!
-	return ws.Get(e[0])
+	var (
+		currentWs = ws
+		lastIndex = len(e) - 1
+	)
+	for i := 0; i < lastIndex; i++ {
+		if value, err := ws.Get(e[i]); err != nil {
+			return nil, err
+		} else if _, ok := value.(*Undefined); ok {
+			return value, nil
+		} else if nextWs, ok := value.(*Worksheet); ok {
+			currentWs = nextWs
+		} else {
+			// TODO(pascal):
+			// 1. How coudl this occur since we validate paths?
+			// 2. Clearer error message wouldn't hurt.
+			return nil, fmt.Errorf("non-sensical selector %v at index %d, not a worksheet, but was %s", e, i, value)
+		}
+	}
+	return currentWs.Get(e[lastIndex])
 }
 
 func (e *tUnop) Args() []string {

--- a/expressions_test.go
+++ b/expressions_test.go
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worksheets
+
+import (
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+var defsForSelectors = MustNewDefinitions(strings.NewReader(`
+worksheet child {
+	1:name text
+}
+
+worksheet parent {
+	2:ref_to_child     child
+	3:refs_to_children []child
+}`))
+
+func (s *Zuite) TestSelectors() {
+	// single field
+	child := defsForSelectors.MustNewWorksheet("child")
+	child.MustSet("name", alice)
+	{
+		actual, err := tSelector([]string{"name"}).Compute(child)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), alice, actual)
+	}
+
+	// path to field
+	parent := defsForSelectors.MustNewWorksheet("parent")
+	parent.MustSet("ref_to_child", child)
+	{
+		actual, err := tSelector([]string{"ref_to_child", "name"}).Compute(parent)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), alice, actual)
+	}
+
+	// slice expression
+	parent.MustAppend("refs_to_children", child)
+	{
+		actual, err := tSelector([]string{"refs_to_children", "name"}).Compute(parent)
+		require.NoError(s.T(), err)
+		slice, ok := actual.(*Slice)
+		require.True(s.T(), ok)
+		require.Equal(s.T(), []Value{alice}, slice.Elements())
+	}
+}

--- a/marshaling.go
+++ b/marshaling.go
@@ -95,7 +95,7 @@ func (m *marshaler) marshalValue(b *bytes.Buffer, value Value) {
 	case *Bool:
 		b.WriteString(strconv.FormatBool(v.value))
 
-	case *slice:
+	case *Slice:
 		b.WriteRune('[')
 		for i := range v.elements {
 			if i != 0 {

--- a/parser.go
+++ b/parser.go
@@ -50,6 +50,7 @@ var (
 	pMult               = newTokenPattern("*", "\\*")
 	pDiv                = newTokenPattern("/", "\\/")
 	pNot                = newTokenPattern("!", "\\!")
+	pDot                = newTokenPattern(".", "\\.")
 	pEqual              = newTokenPattern("==", "\\=\\=")
 	pNotEqual           = newTokenPattern("!=", "\\!\\=")
 	pGreaterThan        = newTokenPattern(">", "\\>")
@@ -276,7 +277,7 @@ func (p *parser) parseExpression(withOp bool) (expression, error) {
 		"literal",
 		"literal",
 		"literal",
-		"var",
+		"ident",
 		"paren",
 		"unop",
 	})
@@ -294,9 +295,17 @@ func (p *parser) parseExpression(withOp bool) (expression, error) {
 		}
 		first = val.(expression)
 
-	case "var":
-		token := p.next()
-		first = &tVar{token}
+	case "ident":
+		path := []string{p.next()}
+		for p.peek(pDot) {
+			p.next()
+			name, err := p.nextAndCheck(pName)
+			if err != nil {
+				return nil, err
+			}
+			path = append(path, name)
+		}
+		first = tSelector(path)
 
 	case "paren":
 		p.next()

--- a/parser.go
+++ b/parser.go
@@ -104,16 +104,20 @@ func (p *parser) parseWorksheet() (*Definition, error) {
 		fieldsByName:  make(map[string]*Field),
 		fieldsByIndex: make(map[int]*Field),
 	}
-	ws.addField(&Field{
+	if err := ws.addField(&Field{
 		index: IndexId,
 		name:  "id",
 		typ:   &TextType{},
-	})
-	ws.addField(&Field{
+	}); err != nil {
+		panic(fmt.Sprintf("unexpected %s", err))
+	}
+	if err := ws.addField(&Field{
 		index: IndexVersion,
 		name:  "version",
 		typ:   &NumberType{},
-	})
+	}); err != nil {
+		panic(fmt.Sprintf("unexpected %s", err))
+	}
 
 	_, err := p.nextAndCheck(pWorksheet)
 	if err != nil {
@@ -136,7 +140,9 @@ func (p *parser) parseWorksheet() (*Definition, error) {
 		if err != nil {
 			return nil, err
 		}
-		ws.addField(field)
+		if err := ws.addField(field); err != nil {
+			return nil, err
+		}
 	}
 
 	_, err = p.nextAndCheck(pRacco)

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,13 +24,11 @@ func (s *Zuite) TestParser_parseWorksheet() {
 	cases := map[string]func(*Definition){
 		`worksheet simple {}`: func(ws *Definition) {
 			require.Equal(s.T(), "simple", ws.name)
-			require.Equal(s.T(), 2+0, len(ws.fields))
 			require.Equal(s.T(), 2+0, len(ws.fieldsByName))
 			require.Equal(s.T(), 2+0, len(ws.fieldsByIndex))
 		},
 		`worksheet simple {42:full_name text}`: func(ws *Definition) {
 			require.Equal(s.T(), "simple", ws.name)
-			require.Equal(s.T(), 2+1, len(ws.fields))
 			require.Equal(s.T(), 2+1, len(ws.fieldsByName))
 			require.Equal(s.T(), 2+1, len(ws.fieldsByIndex))
 
@@ -43,7 +41,8 @@ func (s *Zuite) TestParser_parseWorksheet() {
 		},
 		`  worksheet simple {42:full_name text 45:happy bool}`: func(ws *Definition) {
 			require.Equal(s.T(), "simple", ws.name)
-			require.Equal(s.T(), 2+2, len(ws.fields))
+			require.Equal(s.T(), 2+2, len(ws.fieldsByName))
+			require.Equal(s.T(), 2+2, len(ws.fieldsByIndex))
 
 			field1 := ws.fieldsByName["full_name"]
 			require.Equal(s.T(), 42, field1.index)

--- a/parser_test.go
+++ b/parser_test.go
@@ -91,12 +91,14 @@ func (s *Zuite) TestParser_parseExpression() {
 		`"Alice"`:   &Text{"Alice"},
 		`true`:      &Bool{true},
 
-		// var
-		`foo`: &tVar{"foo"},
+		// selectors
+		`foo`:         tSelector([]string{"foo"}),
+		`foo.bar`:     tSelector([]string{"foo", "bar"}),
+		`foo.bar.baz`: tSelector([]string{"foo", "bar", "baz"}),
 
 		// unop and binop
 		`3 + 4`: &tBinop{opPlus, &Number{3, &NumberType{0}}, &Number{4, &NumberType{0}}, nil},
-		`!foo`:  &tUnop{opNot, &tVar{"foo"}},
+		`!foo`:  &tUnop{opNot, tSelector([]string{"foo"})},
 
 		// parentheses
 		`(true)`:          &Bool{true},

--- a/slices_test.go
+++ b/slices_test.go
@@ -171,7 +171,7 @@ func (s *DbZuite) TestSliceSave() {
 
 	// We're reaching into the data store to get the slice id in order to write
 	// assertions against it.
-	slice := ws.data[42].(*slice)
+	slice := ws.data[42].(*Slice)
 	theSliceId := slice.id
 	slice.lastRank = 89
 
@@ -240,7 +240,7 @@ func (s *DbZuite) TestSliceLoad() {
 		ws.MustAppend("names", bob)
 		ws.MustAppend("names", carol)
 
-		wsId, theSliceId = ws.Id(), (ws.data[42].(*slice)).id
+		wsId, theSliceId = ws.Id(), (ws.data[42].(*Slice)).id
 
 		session := s.store.Open(tx)
 		return session.Save(ws)
@@ -258,7 +258,7 @@ func (s *DbZuite) TestSliceLoad() {
 	})
 	require.Equal(s.T(), []Value{alice, carol, bob, carol}, fresh.MustGetSlice("names"))
 
-	slice := fresh.data[42].(*slice)
+	slice := fresh.data[42].(*Slice)
 	require.Equal(s.T(), theSliceId, slice.id)
 	require.Equal(s.T(), 4, slice.lastRank)
 	require.Equal(s.T(), &SliceType{&TextType{}}, slice.typ)
@@ -275,7 +275,7 @@ func (s *DbZuite) TestSliceUpdate_appendsThenDelThenAppendAgain() {
 		ws.MustAppend("names", alice)
 		ws.MustAppend("names", bob)
 
-		wsId, theSliceId = ws.Id(), (ws.data[42].(*slice)).id
+		wsId, theSliceId = ws.Id(), (ws.data[42].(*Slice)).id
 
 		session := s.store.Open(tx)
 		return session.Save(ws)
@@ -415,7 +415,7 @@ func (s *DbZuite) TestSliceOfRefs_saveLoad() {
 		forciblySetId(simple2, simple2Id)
 
 		// We keep the slice' identifier handy for assertions.
-		wsSliceId = (ws.data[42].(*slice)).id
+		wsSliceId = (ws.data[42].(*Slice)).id
 
 		session := s.store.Open(tx)
 		return session.Save(ws)

--- a/tree.go
+++ b/tree.go
@@ -48,7 +48,7 @@ type Field struct {
 	name          string
 	typ           Type
 	def           *Definition
-	dependants    []*Field
+	dependents    []*Field
 	computedBy    expression
 	constrainedBy expression
 }

--- a/tree.go
+++ b/tree.go
@@ -97,12 +97,8 @@ func (t *tBinop) String() string {
 	return fmt.Sprintf("binop(%s, %s, %s, %s)", t.op, t.left, t.right, t.round)
 }
 
-// TODO(pascal): remove, replace by selector with only one name!
-type tVar struct {
-	name string
-}
-
-// tSelector represents a selector such as `foo.bar`
+// tSelector represents a selector such as referencing a field `foo`, or
+// referencing a field through a path such `foo.bar`.
 type tSelector []string
 
 type tReturn struct {

--- a/tree.go
+++ b/tree.go
@@ -96,9 +96,13 @@ func (t *tBinop) String() string {
 	return fmt.Sprintf("binop(%s, %s, %s, %s)", t.op, t.left, t.right, t.round)
 }
 
+// TODO(pascal): remove, replace by selector with only one name!
 type tVar struct {
 	name string
 }
+
+// tSelector represents a selector such as `foo.bar`
+type tSelector []string
 
 type tReturn struct {
 	expr expression

--- a/tree.go
+++ b/tree.go
@@ -21,10 +21,6 @@ type Definition struct {
 	fields        []*Field
 	fieldsByName  map[string]*Field
 	fieldsByIndex map[int]*Field
-
-	// derived values handling
-	externals  map[int]ComputedBy
-	dependents map[int][]int
 }
 
 func (def *Definition) addField(field *Field) {
@@ -40,6 +36,7 @@ type Field struct {
 	index         int
 	name          string
 	typ           Type
+	dependents    []int
 	computedBy    expression
 	constrainedBy expression
 }
@@ -50,6 +47,10 @@ func (f *Field) Type() Type {
 
 func (f *Field) Name() string {
 	return f.name
+}
+
+func (f *Field) String() string {
+	return fmt.Sprintf("field(%d:%s, %s)", f.index, f.name, f.typ)
 }
 
 type tOp string

--- a/tree.go
+++ b/tree.go
@@ -25,6 +25,11 @@ type Definition struct {
 func (def *Definition) addField(field *Field) error {
 	field.def = def
 
+	// Parsing guarantees user-defined fields are non-negative.
+	if field.index == 0 {
+		return fmt.Errorf("%s.%s: index cannot be zero", def.name, field.name)
+	}
+
 	if _, ok := def.fieldsByIndex[field.index]; ok {
 		return fmt.Errorf("%s.%s: index %d cannot be reused", def.name, field.name, field.index)
 	}

--- a/types.go
+++ b/types.go
@@ -116,5 +116,9 @@ func (def *Definition) FieldByName(name string) *Field {
 }
 
 func (def *Definition) Fields() []*Field {
-	return def.fields
+	var fields []*Field
+	for _, field := range def.fieldsByIndex {
+		fields = append(fields, field)
+	}
+	return fields
 }

--- a/types_test.go
+++ b/types_test.go
@@ -91,16 +91,19 @@ func (s *Zuite) TestWorksheetDefinition_Fields() {
 			index: 1,
 			name:  "name",
 			typ:   &TextType{},
+			def:   defs.defs["simple"],
 		},
 		{
 			index: -2,
 			name:  "id",
 			typ:   &TextType{},
+			def:   defs.defs["simple"],
 		},
 		{
 			index: -1,
 			name:  "version",
 			typ:   &NumberType{},
+			def:   defs.defs["simple"],
 		},
 	}
 	for _, field := range expectedFields {

--- a/values_test.go
+++ b/values_test.go
@@ -37,10 +37,10 @@ func (s *Zuite) TestValueString() {
 		&Number{-4, &NumberType{0}}:    "-4",
 		&Number{-4, &NumberType{2}}:    "-0.04",
 
-		&slice{elements: []sliceElement{
+		&Slice{elements: []sliceElement{
 			{value: &Number{123, &NumberType{1}}},
 		}}: "[12.3]",
-		&slice{elements: []sliceElement{
+		&Slice{elements: []sliceElement{
 			{value: &Bool{true}},
 			{value: &Bool{false}},
 		}}: "[true false]",

--- a/worksheets.go
+++ b/worksheets.go
@@ -415,7 +415,7 @@ func (ws *Worksheet) set(field *Field, value Value) error {
 	}
 
 	// dependents
-	if err := ws.handleDependantUpdates(field, oldValue, value); err != nil {
+	if err := ws.handleDependentUpdates(field, oldValue, value); err != nil {
 		return err
 	}
 
@@ -570,7 +570,7 @@ func (ws *Worksheet) Append(name string, element Value) error {
 	ws.data[index] = slice
 
 	// dependents
-	if err := ws.handleDependantUpdates(field, nil, element); err != nil {
+	if err := ws.handleDependentUpdates(field, nil, element); err != nil {
 		return err
 	}
 
@@ -602,14 +602,14 @@ func (ws *Worksheet) Del(name string, index int) error {
 	ws.data[field.index] = newSlice
 
 	// dependents
-	if err := ws.handleDependantUpdates(field, deletedValue, nil); err != nil {
+	if err := ws.handleDependentUpdates(field, deletedValue, nil); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (ws *Worksheet) handleDependantUpdates(field *Field, oldValue, newValue Value) error {
+func (ws *Worksheet) handleDependentUpdates(field *Field, oldValue, newValue Value) error {
 	for _, dependentField := range field.dependents {
 		// 1. Gather all depedant worksheets which point to this worksheet,
 		// and need to be triggered.

--- a/worksheets.go
+++ b/worksheets.go
@@ -673,6 +673,12 @@ func (ws *Worksheet) handleDependantUpdates(field *Field, oldValue, newValue Val
 		if _, ok := childWs.parents[ws.def.name]; ok {
 			if _, ok := childWs.parents[ws.def.name][field.index]; ok {
 				delete(childWs.parents[ws.def.name][field.index], ws.Id())
+				if len(childWs.parents[ws.def.name][field.index]) == 0 {
+					delete(childWs.parents[ws.def.name], field.index)
+					if len(childWs.parents[ws.def.name]) == 0 {
+						delete(childWs.parents, ws.def.name)
+					}
+				}
 			}
 		}
 	}

--- a/worksheets.go
+++ b/worksheets.go
@@ -611,7 +611,7 @@ func (ws *Worksheet) Del(name string, index int) error {
 
 func (ws *Worksheet) handleDependentUpdates(field *Field, oldValue, newValue Value) error {
 	for _, dependentField := range field.dependents {
-		// 1. Gather all depedant worksheets which point to this worksheet,
+		// 1. Gather all dependent worksheets which point to this worksheet,
 		// and need to be triggered.
 		var allDependents []*Worksheet
 		if dependentField.def == ws.def {

--- a/worksheets.go
+++ b/worksheets.go
@@ -132,7 +132,7 @@ func NewDefinitions(reader io.Reader, opts ...Options) (*Definitions, error) {
 					// set, only upon setting a new value.
 					if field.computedBy != nil {
 						for _, ascendant := range path {
-							ascendant.dependants = append(ascendant.dependants, field)
+							ascendant.dependents = append(ascendant.dependents, field)
 						}
 					}
 				}
@@ -414,7 +414,7 @@ func (ws *Worksheet) set(field *Field, value Value) error {
 		ws.data[index] = value
 	}
 
-	// dependants
+	// dependents
 	if err := ws.handleDependantUpdates(field, oldValue, value); err != nil {
 		return err
 	}
@@ -569,7 +569,7 @@ func (ws *Worksheet) Append(name string, element Value) error {
 	}
 	ws.data[index] = slice
 
-	// dependants
+	// dependents
 	if err := ws.handleDependantUpdates(field, nil, element); err != nil {
 		return err
 	}
@@ -601,7 +601,7 @@ func (ws *Worksheet) Del(name string, index int) error {
 	deletedValue := slice.elements[index].value
 	ws.data[field.index] = newSlice
 
-	// dependants
+	// dependents
 	if err := ws.handleDependantUpdates(field, deletedValue, nil); err != nil {
 		return err
 	}
@@ -610,27 +610,27 @@ func (ws *Worksheet) Del(name string, index int) error {
 }
 
 func (ws *Worksheet) handleDependantUpdates(field *Field, oldValue, newValue Value) error {
-	for _, dependantField := range field.dependants {
+	for _, dependentField := range field.dependents {
 		// 1. Gather all depedant worksheets which point to this worksheet,
 		// and need to be triggered.
-		var allDependants []*Worksheet
-		if dependantField.def == ws.def {
-			allDependants = []*Worksheet{ws}
+		var allDependents []*Worksheet
+		if dependentField.def == ws.def {
+			allDependents = []*Worksheet{ws}
 		} else {
-			for _, parentsByFieldIndex := range ws.parents[dependantField.def.name] {
+			for _, parentsByFieldIndex := range ws.parents[dependentField.def.name] {
 				for _, parent := range parentsByFieldIndex {
-					allDependants = append(allDependants, parent)
+					allDependents = append(allDependents, parent)
 				}
 			}
 		}
 
-		// 2. Trigger the compute by of all dependant worksheets.
-		for _, dependant := range allDependants {
-			updatedValue, err := dependantField.computedBy.Compute(dependant)
+		// 2. Trigger the compute by of all dependent worksheets.
+		for _, dependent := range allDependents {
+			updatedValue, err := dependentField.computedBy.Compute(dependent)
 			if err != nil {
 				return err
 			}
-			if err := dependant.set(dependantField, updatedValue); err != nil {
+			if err := dependent.set(dependentField, updatedValue); err != nil {
 				return err
 			}
 		}

--- a/worksheets.go
+++ b/worksheets.go
@@ -94,28 +94,7 @@ func NewDefinitions(reader io.Reader, opts ...Options) (*Definitions, error) {
 	}
 
 	for _, def := range defs {
-		var (
-			indexesUsed = make(map[int]bool)
-			namesUsed   = make(map[string]bool)
-		)
 		for _, field := range def.fieldsByIndex {
-			// Any bad index?
-			if field.index == 0 {
-				return nil, fmt.Errorf("%s.%s: index cannot be zero", def.name, field.name)
-			}
-
-			// Any index reused?
-			if _, ok := indexesUsed[field.index]; ok {
-				return nil, fmt.Errorf("%s.%s: index %d cannot be reused", def.name, field.name, field.index)
-			}
-			indexesUsed[field.index] = true
-
-			// Any names reused?
-			if _, ok := namesUsed[field.name]; ok {
-				return nil, fmt.Errorf("%s.%s: multiple fields named %s", def.name, field.name, field.name)
-			}
-			namesUsed[field.name] = true
-
 			// Any unresolved externals?
 			if _, ok := field.computedBy.(*tExternal); ok {
 				return nil, fmt.Errorf("%s.%s: missing plugin for external computed_by", def.name, field.name)

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -344,14 +344,14 @@ func (s *Zuite) TestWorksheet_diffSlices() {
 	}
 }
 
-func toSlice(data map[int]Value) *slice {
+func toSlice(data map[int]Value) *Slice {
 	ranks := make([]int, 0, len(data))
 	for rank := range data {
 		ranks = append(ranks, rank)
 	}
 	sort.Ints(ranks)
 
-	slice := &slice{}
+	slice := &Slice{}
 	for _, rank := range ranks {
 		slice.elements = append(slice.elements, sliceElement{
 			rank:  rank,

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -71,7 +71,7 @@ func (s *Zuite) TestNewDefinitionsErrors() {
 		`worksheet simple {
 			42:same_name text
 			43:same_name text
-		}`: `simple.same_name: multiple fields named same_name`,
+		}`: `simple.same_name: name same_name cannot be reused`,
 
 		`worksheet ref_to_worksheet {
 			89:ref_here some_other_worksheet
@@ -105,7 +105,7 @@ func (s *Zuite) TestNewDefinitionsErrors() {
 	}
 	for input, msg := range cases {
 		_, err := NewDefinitions(strings.NewReader(input))
-		assert.EqualError(s.T(), err, msg, input)
+		assert.EqualError(s.T(), err, msg, input+" expecting "+msg)
 	}
 }
 


### PR DESCRIPTION
This is a mostly working first cut of cross worksheet updates. One of the contrived example under test is
```
worksheet parent {
	1:child_amount number[2] computed_by {
		return child.amount
	}
	2:child child
}

worksheet child {
	5:amount number[2]
}
```

**Implementation Notes**
- Expressions such as `foo` or `foo.bar` are now selectors, and we replace the `tVar` type by a `tSelector` type.
- Selectors can either be paths to select a specific field, as in the above example where `child.amount` points to the `amount` field of `child` worksheet, or selectors can be more complex as in `children.amount` where `children` is a `[]child` would be a `[]number[2]` essentially selecting a specific field on a slice level.
- Dependents handling is expanded to cross worksheet dependents. Minor change, instead of having a `map[int]...` on a worksheet definition, we now place the data directly on the field.
- When updating a child field which depends on a parent, we need a way to get to the parent worksheet in order to call its `computed_by`. To this end, we now track all reverse pointers in a `parents` map.
- These reverse pointers, or parents, are essentially tracking all the parents who know about a worksheet, and the path through which they know this worksheet.
- Using the above example, an instance of the `child` worksheet being attached to an instance of a `parent` would have a reverse path of `"parent" -> 2 -> "<uuid>" -> parent`. This reverse path is first the name of the type of worksheet (`"parent"`), the field index through which it is being referenced (`2`), then the UUID, then the reference itself.
- When setting, appending, or deleting, we update and track those reverse pointers.
- And with all this scaffolding, we can finally trigger `computed_by` properly and update all parents appropriately.