### PR TITLE
Cross Worksheet updates, across persistence boundaries

### DIFF
--- a/computed_by_test.go
+++ b/computed_by_test.go
@@ -557,14 +557,9 @@ func (s *DbZuite) TestComputedBy_crossWs_twoParentsOneChildRefsPersistence() {
 		parent1.MustSet("child", child)
 		parent2.MustSet("child", child)
 
-		session := store.Open(tx)
-		if err := session.Save(parent1); err != nil {
-			return err
-		}
-		if err := session.Save(parent2); err != nil {
-			return err
-		}
-		return nil
+		// Since parent1 -> child -> parent2, when saving parent1, we also
+		// save parent2!
+		return store.Open(tx).Save(parent1)
 	})
 
 	// 1. Ensure parent pointers are properly stored on save.

--- a/dbstore.go
+++ b/dbstore.go
@@ -381,18 +381,16 @@ func (p *persister) save(ws *Worksheet) error {
 			Value:       p.writeValue(value),
 		})
 
-		if _, ok := value.(*Slice); !ok {
-			for _, childWs := range extractChildWs(value) {
-				adoptedChildren[index] = append(adoptedChildren[index], childWs.Id())
-			}
-		}
-
 		if slice, ok := value.(*Slice); ok {
 			slicesToInsert = append(slicesToInsert, slice)
 			for _, elem := range slice.elements {
 				for _, childWs := range extractChildWs(elem.value) {
 					adoptedChildren[index] = append(adoptedChildren[index], childWs.Id())
 				}
+			}
+		} else {
+			for _, childWs := range extractChildWs(value) {
+				adoptedChildren[index] = append(adoptedChildren[index], childWs.Id())
 			}
 		}
 	}
@@ -499,6 +497,8 @@ func (p *persister) update(ws *Worksheet) error {
 	)
 	for index, change := range diff {
 		valuesToUpdate = append(valuesToUpdate, index)
+
+		// non-slice values
 		if _, ok := change.before.(*Slice); !ok {
 			for _, childWs := range extractChildWs(change.before) {
 				orphanedChildren[index] = append(orphanedChildren[index], childWs.Id())
@@ -509,6 +509,8 @@ func (p *persister) update(ws *Worksheet) error {
 				adoptedChildren[index] = append(adoptedChildren[index], childWs.Id())
 			}
 		}
+
+		// slice values
 		if sliceAfter, ok := change.after.(*Slice); ok {
 			var sliceBefore *Slice
 			if actualSliceBefore, ok := change.before.(*Slice); ok {

--- a/dbstore.go
+++ b/dbstore.go
@@ -78,6 +78,13 @@ type rValue struct {
 	Value       dat.NullString `db:"value"`
 }
 
+// rParent represents a record of the worksheet_parents table.
+type rParent struct {
+	ChildId          string `db:"child_id"`
+	ParentId         string `db:"parent_id"`
+	ParentFieldIndex int    `db:"parent_field_index"`
+}
+
 // rSliceElement represents a record of the worksheet_slice_elements table.
 type rSliceElement struct {
 	Id          int64          `db:"id"`
@@ -91,6 +98,7 @@ type rSliceElement struct {
 var tableToEntities = map[string]interface{}{
 	"worksheets":               &rWorksheet{},
 	"worksheet_values":         &rValue{},
+	"worksheet_parents":        &rParent{},
 	"worksheet_slice_elements": &rSliceElement{},
 }
 
@@ -134,6 +142,9 @@ type loader struct {
 }
 
 func (l *loader) loadWorksheet(id string) (*Worksheet, error) {
+	// Early exit for worksheets we are already in the process of loading.
+	// Important to note that the returned worksheet may be only partially
+	// hydrated. Callers beware.
 	if ws, ok := l.graph[id]; ok {
 		return ws, nil
 	}
@@ -148,7 +159,6 @@ func (l *loader) loadWorksheet(id string) (*Worksheet, error) {
 	} else if len(wsRecs) == 0 {
 		return nil, fmt.Errorf("unknown worksheet with id %s", id)
 	}
-
 	wsRec := wsRecs[0]
 
 	ws, err := l.s.defs.newUninitializedWorksheet(wsRec.Name)
@@ -156,6 +166,10 @@ func (l *loader) loadWorksheet(id string) (*Worksheet, error) {
 		return nil, err
 	}
 
+	// Before placing the worksheet in the graph, we set the id manually so
+	// callers can rely on this even if the worksheet itself is not fully
+	// loaded.
+	ws.data[IndexId] = NewText(id)
 	l.graph[id] = ws
 
 	var valuesRecs []rValue
@@ -189,6 +203,7 @@ func (l *loader) loadWorksheet(id string) (*Worksheet, error) {
 		}
 	}
 
+	// hydrate slices
 	for {
 		slicesToHydrate := l.nextSlicesToHydrate()
 		if len(slicesToHydrate) == 0 {
@@ -220,6 +235,23 @@ func (l *loader) loadWorksheet(id string) (*Worksheet, error) {
 				value: value,
 			})
 		}
+	}
+
+	// load parents
+	var parentsRecs []rParent
+	if err := l.s.tx.
+		Select("*").
+		From("worksheet_parents").
+		Where("child_id = $1", id).
+		QueryStructs(&parentsRecs); err != nil {
+		return nil, err
+	}
+	for _, parentRec := range parentsRecs {
+		parentWs, err := l.loadWorksheet(parentRec.ParentId)
+		if err != nil {
+			return nil, err
+		}
+		ws.parents.addParentViaFieldIndex(parentWs, parentRec.ParentFieldIndex)
 	}
 
 	return ws, nil
@@ -302,7 +334,7 @@ func (p *persister) save(ws *Worksheet) error {
 	}
 	p.graph[ws.Id()] = true
 
-	// cascade worksheets
+	// cascade updates to children and parents
 	for _, value := range ws.data {
 		for _, wsToCascade := range worksheetsToCascade(value) {
 			if err := p.saveOrUpdate(wsToCascade); err != nil {
@@ -345,6 +377,7 @@ func (p *persister) save(ws *Worksheet) error {
 		return err
 	}
 
+	// insert rSliceElement
 	if len(slicesToInsert) != 0 {
 		insertSliceElements := p.s.tx.InsertInto("worksheet_slice_elements").Columns("*").Blacklist("id")
 		for _, slice := range slicesToInsert {
@@ -359,6 +392,25 @@ func (p *persister) save(ws *Worksheet) error {
 			}
 		}
 		if _, err := insertSliceElements.Exec(); err != nil {
+			return err
+		}
+	}
+
+	// insert rParent
+	if len(ws.parents) != 0 {
+		insertParentElements := p.s.tx.InsertInto("worksheet_parents").Columns("*").Blacklist("id")
+		for _, byName := range ws.parents {
+			for parentFieldIndex, byParentFieldIndex := range byName {
+				for parentId, _ := range byParentFieldIndex {
+					insertParentElements.Record(rParent{
+						ChildId:          ws.Id(),
+						ParentId:         parentId,
+						ParentFieldIndex: parentFieldIndex,
+					})
+				}
+			}
+		}
+		if _, err := insertParentElements.Exec(); err != nil {
 			return err
 		}
 	}
@@ -380,9 +432,18 @@ func (p *persister) update(ws *Worksheet) error {
 
 	// cascade worksheets
 	for _, value := range ws.data {
-		for _, wsToCascade := range worksheetsToCascade(value) {
-			if err := p.saveOrUpdate(wsToCascade); err != nil {
+		for _, childWs := range worksheetsToCascade(value) {
+			if err := p.saveOrUpdate(childWs); err != nil {
 				return err
+			}
+		}
+	}
+	for _, byParentFieldIndex := range ws.parents {
+		for _, byParentId := range byParentFieldIndex {
+			for _, parentWs := range byParentId {
+				if err := p.saveOrUpdate(parentWs); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -409,12 +470,18 @@ func (p *persister) update(ws *Worksheet) error {
 
 	// split the diff into the various changes we need to do
 	var (
-		valuesToUpdate      = make([]int, 0, len(diff))
-		slicesRanksOfDels   = make(map[string][]int)
-		slicesElementsAdded = make(map[string][]sliceElement)
+		valuesToUpdate        = make([]int, 0, len(diff))
+		slicesElementsDeleted = make(map[string][]sliceElement)
+		slicesElementsAdded   = make(map[string][]sliceElement)
+		orphanedChildren      = make(map[int][]interface{})
 	)
 	for index, change := range diff {
 		valuesToUpdate = append(valuesToUpdate, index)
+		if _, ok := change.before.(*Slice); !ok {
+			for _, childWs := range extractChildWs(change.before) {
+				orphanedChildren[index] = append(orphanedChildren[index], childWs.Id())
+			}
+		}
 		if sliceAfter, ok := change.after.(*Slice); ok {
 			var sliceBefore *Slice
 			if actualSliceBefore, ok := change.before.(*Slice); ok {
@@ -422,17 +489,22 @@ func (p *persister) update(ws *Worksheet) error {
 			} else if _, ok := change.before.(*Undefined); ok {
 				sliceBefore = &Slice{id: sliceAfter.id}
 			} else {
-				continue
+				panic(fmt.Sprintf("unexpected: before=%s, after%s", change.before, change.after))
 			}
 			if sliceBefore.id == sliceAfter.id {
-				ranksOfDels, elementsAdded := diffSlices(sliceBefore, sliceAfter)
+				sliceChange := diffSlices(sliceBefore, sliceAfter)
 
 				sliceId := sliceBefore.id
-				if len(ranksOfDels) != 0 {
-					slicesRanksOfDels[sliceId] = ranksOfDels
+				if len(sliceChange.deleted) != 0 {
+					slicesElementsDeleted[sliceId] = sliceChange.deleted
+					for _, del := range sliceChange.deleted {
+						for _, childWs := range extractChildWs(del.value) {
+							orphanedChildren[index] = append(orphanedChildren[index], childWs.Id())
+						}
+					}
 				}
-				if len(elementsAdded) != 0 {
-					slicesElementsAdded[sliceId] = elementsAdded
+				if len(sliceChange.added) != 0 {
+					slicesElementsAdded[sliceId] = sliceChange.added
 				}
 			}
 		}
@@ -466,13 +538,17 @@ func (p *persister) update(ws *Worksheet) error {
 	}
 
 	// slices: deleted elements
-	for sliceId, ranks := range slicesRanksOfDels {
+	for sliceId, dels := range slicesElementsDeleted {
+		var ranks []interface{}
+		for _, del := range dels {
+			ranks = append(ranks, del.rank)
+		}
 		if _, err := p.s.tx.
 			Update("worksheet_slice_elements").
 			Set("to_version", oldVersion).
 			Where("slice_id = $1", sliceId).
 			Where("from_version <= $1 and $1 <= to_version", oldVersion).
-			Where(inClause("rank", len(ranks)), ughconvert(ranks)...).
+			Where(inClause("rank", len(ranks)), ranks...).
 			Exec(); err != nil {
 			return err
 		}
@@ -491,6 +567,42 @@ func (p *persister) update(ws *Worksheet) error {
 			})
 		}
 		if _, err := insert.Exec(); err != nil {
+			return err
+		}
+	}
+
+	// update rParent
+	// TODO(pascal): Possible race condition since we're updating a relation
+	// which is owned by both the parent and child, and we are missing a shared
+	// lock to synchronize on.
+	for index, childrenWsId := range orphanedChildren {
+		if _, err := p.s.tx.DeleteFrom("worksheet_parents").
+			Where("parent_id = $1", ws.Id()).
+			Where("parent_field_index = $1", index).
+			Where(inClause("child_id", len(childrenWsId)), childrenWsId...).
+			Exec(); err != nil {
+			return err
+		}
+	}
+	// TODO(pascal): We can avoid deleteing and recreating rows by doing proper
+	// diffing. This will do for now, we have other things to optimize before!
+	if _, err := p.s.tx.Exec("delete from worksheet_parents where child_id = $1", ws.Id()); err != nil {
+		return err
+	}
+	if len(ws.parents) != 0 {
+		insertParentElements := p.s.tx.InsertInto("worksheet_parents").Columns("*").Blacklist("id")
+		for _, byName := range ws.parents {
+			for parentFieldIndex, byParentFieldIndex := range byName {
+				for parentId, _ := range byParentFieldIndex {
+					insertParentElements.Record(rParent{
+						ChildId:          ws.Id(),
+						ParentId:         parentId,
+						ParentFieldIndex: parentFieldIndex,
+					})
+				}
+			}
+		}
+		if _, err := insertParentElements.Exec(); err != nil {
 			return err
 		}
 	}

--- a/dbstore_test.go
+++ b/dbstore_test.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/mgutz/dat.v2/sqlx-runner"
 )
 
-func (s *DbZuite) TestExample() {
+func (s *DbZuite) TestDbExample() {
 	ws := s.store.defs.MustNewWorksheet("simple")
 	ws.MustSet("name", NewText("Alice"))
 
@@ -38,6 +38,8 @@ func (s *DbZuite) TestExample() {
 		return err
 	})
 
+	require.Len(s.T(), wsFromStore.MustGet("id").String(), 38)
+	require.Equal(s.T(), `1`, wsFromStore.MustGet("version").String())
 	require.Equal(s.T(), `"Alice"`, wsFromStore.MustGet("name").String())
 }
 
@@ -53,7 +55,7 @@ func (s *DbZuite) TestSave() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -111,7 +113,7 @@ func (s *DbZuite) TestUpdate() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -222,7 +224,7 @@ func (s *DbZuite) TestProperlyLoadUndefinedField() {
 	require.False(s.T(), fresh.MustIsSet("age"))
 
 	// Lastly, check db state.
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -383,9 +385,4 @@ func (s *DbZuite) TestSignoffPattern() {
 	// which means that is_signedoff should not have been modified
 	require.Equal(s.T(), "3", ws.MustGet("version").String())
 	require.Equal(s.T(), "false", ws.MustGet("is_signedoff").String())
-}
-
-func (s *DbZuite) MustRunTransaction(fn func(tx *runner.Tx) error) {
-	err := RunTransaction(s.db, fn)
-	require.NoError(s.T(), err)
 }

--- a/refs_test.go
+++ b/refs_test.go
@@ -55,7 +55,7 @@ func (s *DbZuite) TestRefsSave_noDataInRefWorksheet() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -134,7 +134,7 @@ func (s *DbZuite) TestRefsSave_withDataInRefWorksheet() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -232,7 +232,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetAlreadySaved() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -320,7 +320,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetCascadesAnUpdate() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -407,7 +407,7 @@ func (s *DbZuite) TestRefsSave_withCycles() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -454,13 +454,16 @@ func (s *DbZuite) TestRefsLoad_noCycles() {
 	s.MustRunTransaction(func(tx *runner.Tx) error {
 		ws := defs.MustNewWorksheet("with_refs")
 		simple := defs.MustNewWorksheet("simple")
-		ws.MustSet("simple", simple)
-		simple.MustSet("name", bob)
 
 		// We forcibly set both worksheets' identifiers to have a known ordering
 		// when comparing the db state.
 		forciblySetId(ws, wsId)
 		forciblySetId(simple, simpleId)
+
+		// ws.simple = simple
+		// simple.name = bob
+		ws.MustSet("simple", simple)
+		simple.MustSet("name", bob)
 
 		session := s.store.Open(tx)
 		return session.Save(ws)
@@ -541,7 +544,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentNoChangeInChild() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -658,7 +661,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChangesInChild() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -784,7 +787,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChildRequiringToBeSaved() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _ := s.DbState()
+	wsRecs, valuesRecs, _, _ := s.DbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{

--- a/refs_test.go
+++ b/refs_test.go
@@ -220,16 +220,11 @@ func (s *DbZuite) TestRefsSave_refWorksheetAlreadySaved() {
 	forciblySetId(ws, wsId)
 	forciblySetId(simple, simpleId)
 
-	// We first save simple.
+	// We save simple. Because ws is a parent to simple, we will also
+	// saveOrUpdate ws.
 	s.MustRunTransaction(func(tx *runner.Tx) error {
 		session := s.store.Open(tx)
 		return session.Save(simple)
-	})
-
-	// Then we proceed to save ws.
-	s.MustRunTransaction(func(tx *runner.Tx) error {
-		session := s.store.Open(tx)
-		return session.Save(ws)
 	})
 
 	wsRecs, valuesRecs, _, _ := s.DbState()
@@ -305,7 +300,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetCascadesAnUpdate() {
 	forciblySetId(ws, wsId)
 	forciblySetId(simple, simpleId)
 
-	// We first save simple.
+	// We first save simple, this also saves ws since it is a parent.
 	s.MustRunTransaction(func(tx *runner.Tx) error {
 		session := s.store.Open(tx)
 		return session.Save(simple)
@@ -317,7 +312,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetCascadesAnUpdate() {
 	// Then we proceed to save ws.
 	s.MustRunTransaction(func(tx *runner.Tx) error {
 		session := s.store.Open(tx)
-		return session.Save(ws)
+		return session.SaveOrUpdate(ws)
 	})
 
 	wsRecs, valuesRecs, _, _ := s.DbState()

--- a/schema.sql
+++ b/schema.sql
@@ -31,6 +31,15 @@ create table worksheet_values (
   unique(id)
 );
 
+drop table if exists worksheet_parents;
+create table worksheet_parents (
+  child_id           uuid,
+  parent_id          uuid,
+  parent_field_index int,
+
+  unique(child_id, parent_id, parent_field_index)
+);
+
 drop table if exists worksheet_slice_elements;
 create table worksheet_slice_elements (
   id             serial,

--- a/worksheets.go
+++ b/worksheets.go
@@ -54,16 +54,20 @@ func (parents parentsRefs) addParentViaFieldIndex(parent *Worksheet, fieldIndex 
 }
 
 func (parents parentsRefs) removeParentViaFieldIndex(parent *Worksheet, fieldIndex int) {
-	if _, ok := parents[parent.def.name]; ok {
-		if _, ok := parents[parent.def.name][fieldIndex]; ok {
-			delete(parents[parent.def.name][fieldIndex], parent.Id())
-			if len(parents[parent.def.name][fieldIndex]) == 0 {
-				delete(parents[parent.def.name], fieldIndex)
-				if len(parents[parent.def.name]) == 0 {
-					delete(parents, parent.def.name)
-				}
-			}
-		}
+	parentName := parent.def.name
+
+	if _, ok := parents[parentName]; !ok {
+		return
+	} else if _, ok := parents[parentName][fieldIndex]; !ok {
+		return
+	}
+
+	delete(parents[parentName][fieldIndex], parent.Id())
+	if len(parents[parentName][fieldIndex]) == 0 {
+		delete(parents[parentName], fieldIndex)
+	}
+	if len(parents[parentName]) == 0 {
+		delete(parents, parentName)
 	}
 }
 

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -322,45 +322,45 @@ func (s *Zuite) TestWorksheet_diff() {
 
 func (s *Zuite) TestWorksheet_diffSlices() {
 	cases := []struct {
-		before, after map[int]Value
-		ranksOfDels   []int
-		elementsAdded []sliceElement
+		before, after   map[int]Value
+		elementsDeleted []sliceElement
+		elementsAdded   []sliceElement
 	}{
 		{
-			before:        map[int]Value{},
-			after:         map[int]Value{17: alice},
-			ranksOfDels:   nil,
-			elementsAdded: []sliceElement{{rank: 17, value: alice}},
+			before:          map[int]Value{},
+			after:           map[int]Value{17: alice},
+			elementsDeleted: nil,
+			elementsAdded:   []sliceElement{{rank: 17, value: alice}},
 		},
 		{
-			before:        map[int]Value{17: alice},
-			after:         map[int]Value{17: bob},
-			ranksOfDels:   []int{17},
-			elementsAdded: []sliceElement{{rank: 17, value: bob}},
+			before:          map[int]Value{17: alice},
+			after:           map[int]Value{17: bob},
+			elementsDeleted: []sliceElement{{rank: 17, value: alice}},
+			elementsAdded:   []sliceElement{{rank: 17, value: bob}},
 		},
 		{
-			before:        map[int]Value{17: alice},
-			after:         map[int]Value{},
-			ranksOfDels:   []int{17},
-			elementsAdded: nil,
+			before:          map[int]Value{17: alice},
+			after:           map[int]Value{},
+			elementsDeleted: []sliceElement{{rank: 17, value: alice}},
+			elementsAdded:   nil,
 		},
 		{
-			before:        map[int]Value{17: alice, 67: bob},
-			after:         map[int]Value{2: carol, 67: bob},
-			ranksOfDels:   []int{17},
-			elementsAdded: []sliceElement{{2, carol}},
+			before:          map[int]Value{17: alice, 67: bob},
+			after:           map[int]Value{2: carol, 67: bob},
+			elementsDeleted: []sliceElement{{rank: 17, value: alice}},
+			elementsAdded:   []sliceElement{{2, carol}},
 		},
 		{
-			before:        map[int]Value{1: alice, 3: bob, 5: carol},
-			after:         map[int]Value{2: carol},
-			ranksOfDels:   []int{1, 3, 5},
-			elementsAdded: []sliceElement{{2, carol}},
+			before:          map[int]Value{1: alice, 3: bob, 5: carol},
+			after:           map[int]Value{2: carol},
+			elementsDeleted: []sliceElement{{rank: 1, value: alice}, {rank: 3, value: bob}, {rank: 5, value: carol}},
+			elementsAdded:   []sliceElement{{2, carol}},
 		},
 	}
 	for _, ex := range cases {
-		actualRanksOfDels, actualElementsAdded := diffSlices(toSlice(ex.before), toSlice(ex.after))
-		assert.Equal(s.T(), ex.ranksOfDels, actualRanksOfDels, "dels: %v to %v", ex.before, ex.after)
-		assert.Equal(s.T(), ex.elementsAdded, actualElementsAdded, "adds: %v to %v", ex.before, ex.after)
+		sliceChange := diffSlices(toSlice(ex.before), toSlice(ex.after))
+		assert.Equal(s.T(), ex.elementsDeleted, sliceChange.deleted, "dels: %v to %v", ex.before, ex.after)
+		assert.Equal(s.T(), ex.elementsAdded, sliceChange.added, "adds: %v to %v", ex.before, ex.after)
 	}
 }
 


### PR DESCRIPTION
Consider the worksheets
```
worksheet parent {
	1:child_amount number[2] computed_by { return child.amount }
	2:child child
}
worksheet child {
	5:amount number[2]
}
```
when a child is loaded, and its `amount` updated, this must properly flow to its parents. As a result, we must load those parents when loading the child so that updates can flow through properly.

To this end, we now track and persist parent pointers records in a newly introduced `worksheet_parents` table. This change is all about correctly saving and updating those records, as well as correctly loading parents when loading a worksheet.