### PR TITLE
Instead of four returns from DbState, return struct

### DIFF
--- a/computed_by_test.go
+++ b/computed_by_test.go
@@ -492,7 +492,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentsRefsPersistence() {
 	})
 
 	// 1. Ensure parent pointers are properly stored on save.
-	_, _, parentsRecs, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -500,7 +500,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentsRefsPersistence() {
 			ParentId:         parentId,
 			ParentFieldIndex: 2,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 
 	// 2. Ensure parent pointers (and parent worksheets) are correctly loaded.
 	var childParentsAfterLoad parentsRefs
@@ -532,9 +532,9 @@ func (s *DbZuite) TestComputedBy_crossWs_parentsRefsPersistence() {
 		return session.Update(parent)
 	})
 
-	_, _, parentsRecs, _ = s.DbState()
+	snap = s.snapshotDbState()
 
-	require.Empty(s.T(), parentsRecs)
+	require.Empty(s.T(), snap.parentsRecs)
 }
 
 func (s *DbZuite) TestComputedBy_crossWs_twoParentsOneChildRefsPersistence() {
@@ -563,7 +563,7 @@ func (s *DbZuite) TestComputedBy_crossWs_twoParentsOneChildRefsPersistence() {
 	})
 
 	// 1. Ensure parent pointers are properly stored on save.
-	_, _, parentsRecs, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -576,7 +576,7 @@ func (s *DbZuite) TestComputedBy_crossWs_twoParentsOneChildRefsPersistence() {
 			ParentId:         parent2Id,
 			ParentFieldIndex: 2,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 
 	// 2. Ensure that when a ref is removed from a parent, the parent record
 	// is properly removed (even when the child is not loaded), and that no
@@ -591,7 +591,7 @@ func (s *DbZuite) TestComputedBy_crossWs_twoParentsOneChildRefsPersistence() {
 		return session.Update(parent1)
 	})
 
-	_, _, parentsRecs, _ = s.DbState()
+	snap = s.snapshotDbState()
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -599,7 +599,7 @@ func (s *DbZuite) TestComputedBy_crossWs_twoParentsOneChildRefsPersistence() {
 			ParentId:         parent2Id,
 			ParentFieldIndex: 2,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 }
 
 func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
@@ -623,7 +623,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 	})
 
 	// 1. Ensure parent pointers are properly stored on save.
-	_, _, parentsRecs, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -631,7 +631,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 			ParentId:         parentId,
 			ParentFieldIndex: 20,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 
 	// 2. Add another child, ensure the new ref is also recorded.
 	s.MustRunTransaction(func(tx *runner.Tx) error {
@@ -647,7 +647,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 		return session.Update(parent)
 	})
 
-	_, _, parentsRecs, _ = s.DbState()
+	snap = s.snapshotDbState()
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -660,7 +660,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 			ParentId:         parentId,
 			ParentFieldIndex: 20,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 
 	// 3. Remove a child, ensure ref is removed as well.
 	s.MustRunTransaction(func(tx *runner.Tx) error {
@@ -673,7 +673,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 		return session.Update(parent)
 	})
 
-	_, _, parentsRecs, _ = s.DbState()
+	snap = s.snapshotDbState()
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -681,7 +681,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 			ParentId:         parentId,
 			ParentFieldIndex: 20,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 }
 
 func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence2() {
@@ -727,7 +727,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence2() {
 	})
 
 	// Now, ensure parent pointers are properly stored on save.
-	_, _, parentsRecs, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -735,7 +735,7 @@ func (s *DbZuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence2() {
 			ParentId:         parentId,
 			ParentFieldIndex: 20,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 }
 
 func (s *DbZuite) TestComputedBy_crossWs_updateOfChildCarriesToParent() {
@@ -788,8 +788,7 @@ func (s *DbZuite) TestComputedBy_crossWs_updateOfChildCarriesToParent() {
 	})
 	require.Equal(s.T(), `15.54` /* 6.66 + 8.88 */, sumOfChildren.String())
 
-	// Inspect rValues.
-	_, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rValueForTesting{
 		// parent's values
@@ -895,5 +894,5 @@ func (s *DbZuite) TestComputedBy_crossWs_updateOfChildCarriesToParent() {
 			ToVersion:   math.MaxInt32,
 			Value:       `8.88`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 }

--- a/dbstore_test.go
+++ b/dbstore_test.go
@@ -55,7 +55,7 @@ func (s *DbZuite) TestSave() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -63,7 +63,7 @@ func (s *DbZuite) TestSave() {
 			Version: 1,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -87,7 +87,7 @@ func (s *DbZuite) TestSave() {
 			ToVersion:   math.MaxInt32,
 			Value:       `Alice`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Save, orig needs to be set to data.
 	require.Empty(s.T(), ws.diff())
@@ -113,7 +113,7 @@ func (s *DbZuite) TestUpdate() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -121,7 +121,7 @@ func (s *DbZuite) TestUpdate() {
 			Version: 2,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -159,7 +159,7 @@ func (s *DbZuite) TestUpdate() {
 			ToVersion:   math.MaxInt32,
 			Value:       `Bob`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon update, version must increase
 	require.Equal(s.T(), 2, ws.Version())
@@ -224,7 +224,7 @@ func (s *DbZuite) TestProperlyLoadUndefinedField() {
 	require.False(s.T(), fresh.MustIsSet("age"))
 
 	// Lastly, check db state.
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -232,7 +232,7 @@ func (s *DbZuite) TestProperlyLoadUndefinedField() {
 			Version: 2,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -270,7 +270,7 @@ func (s *DbZuite) TestProperlyLoadUndefinedField() {
 			ToVersion:   math.MaxInt32,
 			IsUndefined: true,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 }
 
 func (s *DbZuite) TestUpdateOnUpdateDoesNothing() {

--- a/dbtestutil_test.go
+++ b/dbtestutil_test.go
@@ -85,7 +85,14 @@ type rSliceElementForTesting struct {
 	IsUndefined bool
 }
 
-func (s *DbZuite) DbState() ([]rWorksheet, []rValueForTesting, []rParent, []rSliceElementForTesting) {
+type dbState struct {
+	wsRecs            []rWorksheet
+	valuesRecs        []rValueForTesting
+	parentsRecs       []rParent
+	sliceElementsRecs []rSliceElementForTesting
+}
+
+func (s *DbZuite) snapshotDbState() *dbState {
 	var (
 		err                 error
 		wsRecs              []rWorksheet
@@ -154,7 +161,12 @@ func (s *DbZuite) DbState() ([]rWorksheet, []rValueForTesting, []rParent, []rSli
 		}
 	}
 
-	return wsRecs, valuesRecs, parentsRecs, sliceElementsRecs
+	return &dbState{
+		wsRecs:            wsRecs,
+		valuesRecs:        valuesRecs,
+		parentsRecs:       parentsRecs,
+		sliceElementsRecs: sliceElementsRecs,
+	}
 }
 
 func p(v string) *string {

--- a/refs_test.go
+++ b/refs_test.go
@@ -55,7 +55,7 @@ func (s *DbZuite) TestRefsSave_noDataInRefWorksheet() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -68,7 +68,7 @@ func (s *DbZuite) TestRefsSave_noDataInRefWorksheet() {
 			Version: 1,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -106,7 +106,7 @@ func (s *DbZuite) TestRefsSave_noDataInRefWorksheet() {
 			ToVersion:   math.MaxInt32,
 			Value:       `1`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Save, orig needs to be set to data.
 	require.Empty(s.T(), ws.diff())
@@ -134,7 +134,7 @@ func (s *DbZuite) TestRefsSave_withDataInRefWorksheet() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -147,7 +147,7 @@ func (s *DbZuite) TestRefsSave_withDataInRefWorksheet() {
 			Version: 1,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -199,7 +199,7 @@ func (s *DbZuite) TestRefsSave_withDataInRefWorksheet() {
 			ToVersion:   math.MaxInt32,
 			Value:       `120`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Save, orig needs to be set to data.
 	require.Empty(s.T(), ws.diff())
@@ -227,7 +227,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetAlreadySaved() {
 		return session.Save(simple)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -240,7 +240,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetAlreadySaved() {
 			Version: 1,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -278,7 +278,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetAlreadySaved() {
 			ToVersion:   math.MaxInt32,
 			Value:       `1`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Save, orig needs to be set to data.
 	require.Empty(s.T(), ws.diff())
@@ -315,7 +315,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetCascadesAnUpdate() {
 		return session.SaveOrUpdate(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -328,7 +328,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetCascadesAnUpdate() {
 			Version: 2,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -387,7 +387,7 @@ func (s *DbZuite) TestRefsSave_refWorksheetCascadesAnUpdate() {
 			ToVersion:   math.MaxInt32,
 			Value:       `Carol`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Save, orig needs to be set to data.
 	require.Empty(s.T(), ws.diff())
@@ -402,7 +402,7 @@ func (s *DbZuite) TestRefsSave_withCycles() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -410,7 +410,7 @@ func (s *DbZuite) TestRefsSave_withCycles() {
 			Version: 1,
 			Name:    "with_refs_and_cycles",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -434,7 +434,7 @@ func (s *DbZuite) TestRefsSave_withCycles() {
 			ToVersion:   math.MaxInt32,
 			Value:       fmt.Sprintf(`*:%s`, ws.Id()),
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Save, orig needs to be set to data.
 	require.Empty(s.T(), ws.diff())
@@ -539,7 +539,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentNoChangeInChild() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -552,7 +552,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentNoChangeInChild() {
 			Version: 1,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -618,7 +618,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentNoChangeInChild() {
 			ToVersion:   math.MaxInt32,
 			Value:       `Carol`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Update, there should be no more changes to persist.
 	require.Empty(s.T(), ws.diff())
@@ -656,7 +656,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChangesInChild() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -669,7 +669,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChangesInChild() {
 			Version: 2,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -749,7 +749,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChangesInChild() {
 			ToVersion:   math.MaxInt32,
 			Value:       `Bob`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Update, there should be no more changes to persist.
 	require.Empty(s.T(), ws.diff())
@@ -782,7 +782,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChildRequiringToBeSaved() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _, _ := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -795,7 +795,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChildRequiringToBeSaved() {
 			Version: 1,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -840,7 +840,7 @@ func (s *DbZuite) TestRefsUpdate_updateParentWithChildRequiringToBeSaved() {
 			ToVersion:   math.MaxInt32,
 			Value:       `1`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	// Upon Update, there should be no more changes to persist.
 	require.Empty(s.T(), ws.diff())

--- a/slices_test.go
+++ b/slices_test.go
@@ -180,7 +180,7 @@ func (s *DbZuite) TestSliceSave() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, _, sliceElementsRecs := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -188,7 +188,7 @@ func (s *DbZuite) TestSliceSave() {
 			Version: 1,
 			Name:    "with_slice",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -212,7 +212,7 @@ func (s *DbZuite) TestSliceSave() {
 			ToVersion:   math.MaxInt32,
 			Value:       fmt.Sprintf(`[:89:%s`, theSliceId),
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	require.Equal(s.T(), []rSliceElementForTesting{
 		{
@@ -222,7 +222,7 @@ func (s *DbZuite) TestSliceSave() {
 			Rank:        1,
 			Value:       `Alice`,
 		},
-	}, sliceElementsRecs)
+	}, snap.sliceElementsRecs)
 
 	// Upon Save, orig needs to be set to data.
 	require.Empty(s.T(), ws.diff())
@@ -303,7 +303,7 @@ func (s *DbZuite) TestSliceUpdate_appendsThenDelThenAppendAgain() {
 		return session.Update(ws)
 	})
 
-	wsRecs, valuesRecs, _, sliceElementsRecs := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -311,7 +311,7 @@ func (s *DbZuite) TestSliceUpdate_appendsThenDelThenAppendAgain() {
 			Version: 3,
 			Name:    "with_slice",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -363,7 +363,7 @@ func (s *DbZuite) TestSliceUpdate_appendsThenDelThenAppendAgain() {
 			ToVersion:   math.MaxInt32,
 			Value:       fmt.Sprintf(`[:3:%s`, theSliceId),
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	require.Equal(s.T(), []rSliceElementForTesting{
 		{
@@ -387,7 +387,7 @@ func (s *DbZuite) TestSliceUpdate_appendsThenDelThenAppendAgain() {
 			Rank:        3,
 			Value:       `Alice`,
 		},
-	}, sliceElementsRecs)
+	}, snap.sliceElementsRecs)
 }
 
 func (s *DbZuite) TestSliceOfRefs_saveLoad() {
@@ -425,7 +425,7 @@ func (s *DbZuite) TestSliceOfRefs_saveLoad() {
 		return session.Save(ws)
 	})
 
-	wsRecs, valuesRecs, parentsRecs, sliceElementsRecs := s.DbState()
+	snap := s.snapshotDbState()
 
 	require.Equal(s.T(), []rWorksheet{
 		{
@@ -443,7 +443,7 @@ func (s *DbZuite) TestSliceOfRefs_saveLoad() {
 			Version: 1,
 			Name:    "simple",
 		},
-	}, wsRecs)
+	}, snap.wsRecs)
 
 	require.Equal(s.T(), []rValueForTesting{
 		{
@@ -509,7 +509,7 @@ func (s *DbZuite) TestSliceOfRefs_saveLoad() {
 			ToVersion:   math.MaxInt32,
 			Value:       `Bob`,
 		},
-	}, valuesRecs)
+	}, snap.valuesRecs)
 
 	require.Equal(s.T(), []rParent{
 		{
@@ -522,7 +522,7 @@ func (s *DbZuite) TestSliceOfRefs_saveLoad() {
 			ParentId:         wsId,
 			ParentFieldIndex: 42,
 		},
-	}, parentsRecs)
+	}, snap.parentsRecs)
 
 	require.Equal(s.T(), []rSliceElementForTesting{
 		{
@@ -539,7 +539,7 @@ func (s *DbZuite) TestSliceOfRefs_saveLoad() {
 			Rank:        2,
 			Value:       fmt.Sprintf("*:%s", simple2Id),
 		},
-	}, sliceElementsRecs)
+	}, snap.sliceElementsRecs)
 
 	// Load into a fresh worksheet, and look at the slice.
 	var fresh *Worksheet


### PR DESCRIPTION
Calling it `snapshotDbState` and it returns a `dbState` struct.