### PR TITLE
Ability to clone a worksheet

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worksheets
+
+import (
+	"fmt"
+
+	"github.com/satori/go.uuid"
+)
+
+// Clone duplicates this worksheet, and all worksheets it points to, in order
+// to create a deep-copy.
+func (ws *Worksheet) Clone() *Worksheet {
+	c := &cloner{
+		mapping: make(map[string]string),
+		clones:  make(map[string]*Worksheet),
+	}
+
+	return c.cloneWs(ws)
+}
+
+type cloner struct {
+	// mapping maps original ws ids, to dupped ws ids
+	mapping map[string]string
+
+	// clones records all dupped worksheets by their ids
+	clones map[string]*Worksheet
+}
+
+func (c *cloner) clone(parent *Worksheet, index int, value Value) Value {
+	switch v := value.(type) {
+	case *Worksheet:
+		child := c.cloneWs(v)
+		child.parents.addParentViaFieldIndex(parent, index)
+		return child
+	case *Slice:
+		dupSlice := newSlice(v.typ)
+		for _, element := range v.Elements() {
+			var err error
+			dupElement := c.clone(parent, index, element)
+			dupSlice, err = dupSlice.doAppend(dupElement)
+			if err != nil {
+				panic(fmt.Sprintf("unexpected %s", err))
+			}
+		}
+		return dupSlice
+	default:
+		return value
+	}
+}
+
+func (c *cloner) cloneWs(ws *Worksheet) *Worksheet {
+	if _, ok := c.mapping[ws.Id()]; ok {
+		return c.clones[c.mapping[ws.Id()]]
+	}
+
+	// When duplicating a worksheet, we change the underlying data structures
+	// directly to make an exact copy of the values, rather than go through
+	// constrained fields, computed fields, etc. This guarantees that the
+	// copy is done at the value level, and yields the same data, even in the
+	// case where definitions for various fields have changed since the creation
+	// of ws.
+
+	dup := ws.def.newUninitializedWorksheet()
+	dup.data[indexId] = NewText(uuid.Must(uuid.NewV4()).String())
+	dup.data[indexVersion] = MustNewValue("1")
+	c.mapping[ws.Id()] = dup.Id()
+	c.clones[dup.Id()] = dup
+
+	for index, value := range ws.data {
+		if 0 < index {
+			dup.data[index] = c.clone(dup, index, value)
+		}
+	}
+
+	return dup
+}

--- a/clone.go
+++ b/clone.go
@@ -70,6 +70,8 @@ func (c *cloner) cloneWs(ws *Worksheet) *Worksheet {
 	// copy is done at the value level, and yields the same data, even in the
 	// case where definitions for various fields have changed since the creation
 	// of ws.
+	// The duplicated worksheet is a fresh new instance, with its own id, and
+	// its version set at 1.
 
 	dup := ws.def.newUninitializedWorksheet()
 	dup.data[indexId] = NewText(uuid.Must(uuid.NewV4()).String())

--- a/clone_test.go
+++ b/clone_test.go
@@ -1,0 +1,229 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package worksheets
+
+import (
+	"strings"
+
+	"github.com/stretchr/testify/require"
+)
+
+var cloneDefs = MustNewDefinitions(strings.NewReader(`
+worksheet dup_me {
+	1: value   text
+	2: v_slice []number[0]
+	3: r_slice []dup_me
+	4: ref1    dup_me
+	5: ref2    dup_me
+}
+`))
+
+func (s *Zuite) TestClone_simple() {
+	ws := cloneDefs.MustNewWorksheet("dup_me")
+	ws.MustSet("value", NewText("Mary had a little lamb"))
+
+	dup := ws.Clone()
+	require.True(s.T(), ws != dup, "dup must be a different instance than ws")
+	require.NotEqual(s.T(), ws.Id(), dup.Id())
+	require.Len(s.T(), dup.orig, 0)
+	require.Equal(s.T(), map[int]Value{
+		indexId:      NewText(dup.Id()),
+		indexVersion: MustNewValue("1"),
+		1:            NewText("Mary had a little lamb"),
+	}, dup.data)
+	require.Len(s.T(), dup.parents, 0)
+}
+
+func (s *Zuite) TestClone_withOneWsRef() {
+	ws1 := cloneDefs.MustNewWorksheet("dup_me")
+	ws2 := cloneDefs.MustNewWorksheet("dup_me")
+	ws1.MustSet("ref1", ws2)
+
+	dup1 := ws1.Clone()
+	dup2 := dup1.MustGet("ref1").(*Worksheet)
+
+	require.True(s.T(), ws1 != dup1, "dup1 must be a different instance than ws1")
+	require.True(s.T(), ws2 != dup2, "dup2 must be a different instance than ws2")
+
+	require.NotEqual(s.T(), ws1.Id(), dup1.Id())
+	require.NotEqual(s.T(), ws2.Id(), dup2.Id())
+
+	require.Len(s.T(), dup1.orig, 0)
+	require.Len(s.T(), dup2.orig, 0)
+
+	require.Equal(s.T(), map[int]Value{
+		indexId:      NewText(dup1.Id()),
+		indexVersion: MustNewValue("1"),
+		4:            dup2,
+	}, dup1.data)
+	require.Equal(s.T(), map[int]Value{
+		indexId:      NewText(dup2.Id()),
+		indexVersion: MustNewValue("1"),
+	}, dup2.data)
+
+	require.Len(s.T(), dup1.parents, 0)
+	require.Equal(s.T(), parentsRefs(map[string]map[int]map[string]*Worksheet{
+		"dup_me": {
+			4: {
+				dup1.Id(): dup1,
+			},
+		},
+	}), dup2.parents)
+}
+
+func (s *Zuite) TestClone_withTwoWsRefToSameWs() {
+	ws1 := cloneDefs.MustNewWorksheet("dup_me")
+	ws2 := cloneDefs.MustNewWorksheet("dup_me")
+	ws1.MustSet("ref1", ws2)
+	ws1.MustSet("ref2", ws2)
+
+	dup1 := ws1.Clone()
+	dup2a := dup1.MustGet("ref1").(*Worksheet)
+	dup2b := dup1.MustGet("ref2").(*Worksheet)
+
+	require.True(s.T(), ws1 != dup1, "dup1 must be a different instance than ws1")
+	require.True(s.T(), ws2 != dup2a, "dup2a must be a different instance than ws2")
+	require.True(s.T(), ws2 != dup2b, "dup2b must be a different instance than ws2")
+	require.True(s.T(), dup2a == dup2b, "dup2a must be the same instance as dup2b")
+
+	dup2 := dup2a // == dup2b
+
+	require.NotEqual(s.T(), ws1.Id(), dup1.Id())
+	require.NotEqual(s.T(), ws2.Id(), dup2.Id())
+
+	require.Len(s.T(), dup1.orig, 0)
+	require.Len(s.T(), dup2a.orig, 0)
+
+	require.Equal(s.T(), map[int]Value{
+		indexId:      NewText(dup1.Id()),
+		indexVersion: MustNewValue("1"),
+		4:            dup2,
+		5:            dup2,
+	}, dup1.data)
+	require.Equal(s.T(), map[int]Value{
+		indexId:      NewText(dup2.Id()),
+		indexVersion: MustNewValue("1"),
+	}, dup2.data)
+
+	require.Len(s.T(), dup1.parents, 0)
+	require.Equal(s.T(), parentsRefs(map[string]map[int]map[string]*Worksheet{
+		"dup_me": {
+			4: {
+				dup1.Id(): dup1,
+			},
+			5: {
+				dup1.Id(): dup1,
+			},
+		},
+	}), dup2.parents)
+}
+
+func (s *Zuite) TestClone_withSliceOfValues() {
+	ws := cloneDefs.MustNewWorksheet("dup_me")
+	ws.MustAppend("v_slice", MustNewValue("2"))
+	ws.MustAppend("v_slice", MustNewValue("3"))
+	ws.MustAppend("v_slice", MustNewValue("3"))
+	ws.MustAppend("v_slice", MustNewValue("5"))
+	ws.MustAppend("v_slice", MustNewValue("8"))
+	ws.MustAppend("v_slice", MustNewValue("13"))
+	ws.MustDel("v_slice", 2)
+	wsSlice := ws.data[2].(*Slice)
+
+	dup := ws.Clone()
+	require.True(s.T(), ws != dup, "dup must be a different instance than ws")
+	require.NotEqual(s.T(), ws.Id(), dup.Id())
+	require.Len(s.T(), dup.orig, 0)
+	require.Len(s.T(), dup.data, 3)
+	require.Len(s.T(), dup.parents, 0)
+
+	// Highlighting that dupSlice is a fresh new slice, where elements have been
+	// set to exactly what is in wsSlice at the time of doing the cloning, i.e.
+	// the lastRank is not preserved, because we are doing a clean slate copy.
+	// For wsSlice lastRank is 6, since we've added 6 elements, and removed one,
+	// but for dupSlice, the lastRank is 5, since we're only copying the 5
+	// remaining elements when cloning.
+	require.Equal(s.T(), 6, wsSlice.lastRank)
+
+	dupSlice := dup.data[2].(*Slice)
+	require.NotEqual(s.T(), wsSlice.id, dupSlice.id)
+	require.Equal(s.T(), wsSlice.typ, dupSlice.typ)
+	require.Equal(s.T(), 5, dupSlice.lastRank)
+	require.Equal(s.T(), []sliceElement{
+		{1, MustNewValue("2")},
+		{2, MustNewValue("3")},
+		{3, MustNewValue("5")},
+		{4, MustNewValue("8")},
+		{5, MustNewValue("13")},
+	}, dupSlice.elements)
+}
+
+func (s *Zuite) TestClone_withSliceOfRefs() {
+	ws := cloneDefs.MustNewWorksheet("dup_me")
+	child1 := cloneDefs.MustNewWorksheet("dup_me")
+	child2 := cloneDefs.MustNewWorksheet("dup_me")
+	child3 := cloneDefs.MustNewWorksheet("dup_me")
+	ws.MustAppend("r_slice", child1)
+	ws.MustAppend("r_slice", child2)
+	ws.MustAppend("r_slice", child3)
+	ws.MustSet("ref1", child1)
+	ws.MustSet("ref2", child2)
+
+	dup := ws.Clone()
+
+	// Since we're testing cloning behavior in other tests, we're only checking
+	// that all pointers are set properly here.
+
+	dupSlice := dup.data[3].(*Slice)
+	dupChild1 := dupSlice.elements[0].value.(*Worksheet)
+	dupChild2 := dupSlice.elements[1].value.(*Worksheet)
+	dupChild3 := dupSlice.elements[2].value.(*Worksheet)
+
+	require.True(s.T(), ws != dup, "dup must be a different instance than ws")
+	require.True(s.T(), child1 != dupChild1, "dupChild1 must be a different instance than child1")
+	require.True(s.T(), child2 != dupChild2, "dupChild2 must be a different instance than child2")
+	require.True(s.T(), child3 != dupChild3, "dupChild3 must be a different instance than child3")
+
+	require.True(s.T(), dup.data[4] == dupChild1, "r_slice[0] should point to ref1")
+	require.True(s.T(), dup.data[5] == dupChild2, "r_slice[1] should point to ref2")
+
+	// Parents.
+
+	require.Len(s.T(), dup.parents, 0)
+	require.Equal(s.T(), parentsRefs(map[string]map[int]map[string]*Worksheet{
+		"dup_me": {
+			3: {
+				dup.Id(): dup,
+			},
+			4: {
+				dup.Id(): dup,
+			},
+		},
+	}), dupChild1.parents)
+	require.Equal(s.T(), parentsRefs(map[string]map[int]map[string]*Worksheet{
+		"dup_me": {
+			3: {
+				dup.Id(): dup,
+			},
+			5: {
+				dup.Id(): dup,
+			},
+		},
+	}), dupChild2.parents)
+	require.Equal(s.T(), parentsRefs(map[string]map[int]map[string]*Worksheet{
+		"dup_me": {
+			3: {
+				dup.Id(): dup,
+			},
+		},
+	}), dupChild3.parents)
+}

--- a/clone_test.go
+++ b/clone_test.go
@@ -31,10 +31,12 @@ worksheet dup_me {
 func (s *Zuite) TestClone_simple() {
 	ws := cloneDefs.MustNewWorksheet("dup_me")
 	ws.MustSet("value", NewText("Mary had a little lamb"))
+	ws.data[indexVersion] = MustNewValue("666")
 
 	dup := ws.Clone()
 	require.True(s.T(), ws != dup, "dup must be a different instance than ws")
 	require.NotEqual(s.T(), ws.Id(), dup.Id())
+	require.Equal(s.T(), 1, dup.Version())
 	require.Len(s.T(), dup.orig, 0)
 	require.Equal(s.T(), map[int]Value{
 		indexId:      NewText(dup.Id()),

--- a/slices_test.go
+++ b/slices_test.go
@@ -109,11 +109,14 @@ func (s *Zuite) TestSliceErrors_delOnNonSliceFailsEvenIfUndefined() {
 func (s *Zuite) TestSliceOps() {
 	slice1 := newSliceWithIdAndLastRank(&SliceType{&TextType{}}, "a-cool-id", 0)
 
+	require.Equal(s.T(), 0, slice1.lastRank)
 	require.Len(s.T(), slice1.elements, 0)
 
 	slice2, err := slice1.doAppend(alice)
 	require.NoError(s.T(), err)
 
+	require.Equal(s.T(), 0, slice1.lastRank)
+	require.Equal(s.T(), 1, slice2.lastRank)
 	require.Len(s.T(), slice1.elements, 0)
 	require.Len(s.T(), slice2.elements, 1)
 	require.Equal(s.T(), alice, slice2.elements[0].value)
@@ -121,6 +124,9 @@ func (s *Zuite) TestSliceOps() {
 	slice3, err := slice2.doDel(0)
 	require.NoError(s.T(), err)
 
+	require.Equal(s.T(), 0, slice1.lastRank)
+	require.Equal(s.T(), 1, slice2.lastRank)
+	require.Equal(s.T(), 1, slice3.lastRank)
 	require.Len(s.T(), slice1.elements, 0)
 	require.Len(s.T(), slice2.elements, 1)
 	require.Equal(s.T(), sliceElement{1, alice}, slice2.elements[0])
@@ -129,6 +135,10 @@ func (s *Zuite) TestSliceOps() {
 	slice4, err := slice3.doAppend(carol)
 	require.NoError(s.T(), err)
 
+	require.Equal(s.T(), 0, slice1.lastRank)
+	require.Equal(s.T(), 1, slice2.lastRank)
+	require.Equal(s.T(), 1, slice3.lastRank)
+	require.Equal(s.T(), 2, slice4.lastRank)
 	require.Len(s.T(), slice1.elements, 0)
 	require.Len(s.T(), slice2.elements, 1)
 	require.Equal(s.T(), sliceElement{1, alice}, slice2.elements[0])
@@ -139,6 +149,11 @@ func (s *Zuite) TestSliceOps() {
 	slice5, err := slice4.doAppend(bob)
 	require.NoError(s.T(), err)
 
+	require.Equal(s.T(), 0, slice1.lastRank)
+	require.Equal(s.T(), 1, slice2.lastRank)
+	require.Equal(s.T(), 1, slice3.lastRank)
+	require.Equal(s.T(), 2, slice4.lastRank)
+	require.Equal(s.T(), 3, slice5.lastRank)
 	require.Len(s.T(), slice1.elements, 0)
 	require.Len(s.T(), slice2.elements, 1)
 	require.Equal(s.T(), sliceElement{1, alice}, slice2.elements[0])
@@ -152,6 +167,12 @@ func (s *Zuite) TestSliceOps() {
 	slice6, err := slice5.doDel(0)
 	require.NoError(s.T(), err)
 
+	require.Equal(s.T(), 0, slice1.lastRank)
+	require.Equal(s.T(), 1, slice2.lastRank)
+	require.Equal(s.T(), 1, slice3.lastRank)
+	require.Equal(s.T(), 2, slice4.lastRank)
+	require.Equal(s.T(), 3, slice5.lastRank)
+	require.Equal(s.T(), 3, slice6.lastRank)
 	require.Len(s.T(), slice1.elements, 0)
 	require.Len(s.T(), slice2.elements, 1)
 	require.Equal(s.T(), sliceElement{1, alice}, slice2.elements[0])

--- a/values.go
+++ b/values.go
@@ -405,12 +405,10 @@ func (value *Slice) doAppend(element Value) (*Slice, error) {
 	}
 
 	nextRank := value.lastRank + 1
-	value.lastRank++
-
 	slice := &Slice{
 		id:       value.id,
 		typ:      value.typ,
-		lastRank: value.lastRank,
+		lastRank: nextRank,
 		elements: append(value.elements, sliceElement{
 			rank:  nextRank,
 			value: element,

--- a/worksheets.go
+++ b/worksheets.go
@@ -314,14 +314,16 @@ func (defs *Definitions) newUninitializedWorksheet(name string) (*Worksheet, err
 		return nil, fmt.Errorf("unknown worksheet %s", name)
 	}
 
-	ws := &Worksheet{
+	return def.newUninitializedWorksheet(), nil
+}
+
+func (def *Definition) newUninitializedWorksheet() *Worksheet {
+	return &Worksheet{
 		def:     def,
 		orig:    make(map[int]Value),
 		data:    make(map[int]Value),
 		parents: make(map[string]map[int]map[string]*Worksheet),
 	}
-
-	return ws, nil
 }
 
 func (ws *Worksheet) validate() error {


### PR DESCRIPTION
Adding `Clone()` method on a worksheet. This does a deep-copy of the underlying worksheet, and all of its data structures.

(Fixing `doAppend` which was modifying `lastRank` of the slice being appended to, instead of only setting a new value in the new slice which contains the appended element.)