### PR TITLE
Cleanups

### DIFF
--- a/dbstore.go
+++ b/dbstore.go
@@ -409,7 +409,7 @@ func (p *persister) save(ws *Worksheet) error {
 
 	// cascade updates to children and parents
 	for _, value := range ws.data {
-		for _, childWs := range worksheetsToCascade(value) {
+		for _, childWs := range extractChildWs(value) {
 			if err := p.saveOrUpdate(childWs); err != nil {
 				return err
 			}
@@ -537,7 +537,7 @@ func (p *persister) update(ws *Worksheet) error {
 
 	// cascade updates to children and parents
 	for _, value := range ws.data {
-		for _, childWs := range worksheetsToCascade(value) {
+		for _, childWs := range extractChildWs(value) {
 			if err := p.saveOrUpdate(childWs); err != nil {
 				return err
 			}
@@ -787,21 +787,6 @@ func ughconvert(ids []int) []interface{} {
 		convert[i] = ids[i]
 	}
 	return convert
-}
-
-func worksheetsToCascade(value Value) []*Worksheet {
-	switch v := value.(type) {
-	case *Worksheet:
-		return []*Worksheet{v}
-	case *Slice:
-		var result []*Worksheet
-		for _, element := range v.elements {
-			result = append(result, worksheetsToCascade(element.value)...)
-		}
-		return result
-	default:
-		return nil
-	}
 }
 
 func isSpecificUniqueConstraintErr(err error, uniqueConstraintName string) bool {

--- a/expressions.go
+++ b/expressions.go
@@ -382,7 +382,7 @@ var functions = map[string]struct {
 		}
 
 		if _, ok := arg1.(*Undefined); ok {
-			return &Undefined{}, nil
+			return vUndefined, nil
 		}
 		conditions, ok := arg1.(*Slice)
 		if !ok {
@@ -404,10 +404,10 @@ var functions = map[string]struct {
 						sum = sum.Plus(num)
 					}
 				} else {
-					return &Undefined{}, nil
+					return vUndefined, nil
 				}
 			} else {
-				return &Undefined{}, nil
+				return vUndefined, nil
 			}
 		}
 		return sum, nil

--- a/marshaling_test.go
+++ b/marshaling_test.go
@@ -371,7 +371,13 @@ func (s *Zuite) TestStructScan_convert() {
 		// {MustNewValue("18_446_744_073_709_551_615"), int64Typ, uint64(18446744073709551615)},
 	}
 	for _, ex := range cases {
-		actual, err := convert("Dest", "source", ex.dest, ex.source.Type(), ex.source)
+		ctx := convertCtx{
+			sourceFieldName: "source",
+			sourceType:      ex.source.Type(),
+			destFieldName:   "Dest",
+			destType:        ex.dest,
+		}
+		actual, err := convert(ctx, ex.source)
 		require.NoError(s.T(), err)
 		assert.Equal(s.T(), ex.expected, actual.Interface())
 	}
@@ -420,8 +426,13 @@ func (s *Zuite) TestStructScan_convertErrors() {
 		// {MustNewValue("18_446_744_073_709_551_616"), int64Typ, "number[0] to int64, value out of range"},
 	}
 	for _, ex := range cases {
-		require.Equal(s.T(), reflect.Int, intTyp.Kind())
-		_, err := convert("Dest", "source", ex.dest, ex.source.Type(), ex.source)
+		ctx := convertCtx{
+			sourceFieldName: "source",
+			sourceType:      ex.source.Type(),
+			destFieldName:   "Dest",
+			destType:        ex.dest,
+		}
+		_, err := convert(ctx, ex.source)
 		assert.EqualError(s.T(), err, "field source to struct field Dest: cannot convert "+ex.expected)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -23,6 +23,8 @@ type Type interface {
 
 	// String returns a string representation of the type.
 	String() string
+
+	dbReadValue(l *loader, value string) (Value, error)
 }
 
 // Assert that all type literals are Type.

--- a/values.go
+++ b/values.go
@@ -46,6 +46,8 @@ type Value interface {
 
 	// String returns a string representation of the value.
 	String() string
+
+	dbWriteValue() string
 }
 
 var _ []Value = []Value{

--- a/values.go
+++ b/values.go
@@ -50,7 +50,7 @@ type Value interface {
 
 var _ []Value = []Value{
 	// Assert that all literals are Value.
-	&Undefined{},
+	vUndefined,
 	&Number{},
 	&Text{},
 	&Bool{},

--- a/values.go
+++ b/values.go
@@ -15,6 +15,7 @@ package worksheets
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -49,6 +50,7 @@ type Value interface {
 
 	dbWriteValue() string
 	jsonMarshalValue(m *marshaler, b *bytes.Buffer)
+	structScanConvert(ctx convertCtx) (reflect.Value, error)
 }
 
 var _ []Value = []Value{

--- a/values.go
+++ b/values.go
@@ -48,6 +48,7 @@ type Value interface {
 	String() string
 
 	dbWriteValue() string
+	jsonMarshalValue(m *marshaler, b *bytes.Buffer)
 }
 
 var _ []Value = []Value{

--- a/worksheets.go
+++ b/worksheets.go
@@ -684,13 +684,18 @@ func (ws *Worksheet) handleDependentUpdates(field *Field, oldValue, newValue Val
 }
 
 func extractChildWs(value Value) []*Worksheet {
-	if childWs, ok := value.(*Worksheet); ok {
-		return []*Worksheet{childWs}
+	switch v := value.(type) {
+	case *Worksheet:
+		return []*Worksheet{v}
+	case *Slice:
+		var result []*Worksheet
+		for _, element := range v.elements {
+			result = append(result, extractChildWs(element.value)...)
+		}
+		return result
+	default:
+		return nil
 	}
-	if _, ok := value.(*Slice); ok {
-		panic("slices-of-slices are not supported yet")
-	}
-	return nil
 }
 
 type change struct {

--- a/worksheets.go
+++ b/worksheets.go
@@ -204,6 +204,10 @@ func (s tSelector) Select(elemType Type) ([]*Field, bool) {
 	return nil, false
 }
 
+// resolveRefTypes resolves type references, e.g. `some_name`, to the actual
+// type definition for these references. During parsing, empty instances of
+// `Definition` are used, which are here replaced with the actual proper
+// definition from the `defs` map.
 func resolveRefTypes(niceFieldName string, defs map[string]*Definition, locus interface{}) error {
 	switch locus.(type) {
 	case *Field:


### PR DESCRIPTION
This introduces three functions on `Value` (and one on `Type`), to leverage go’s dynamic dispatch rather than rely on type switches. This will make it more natural to introduce a `date` and `enum` type, and will make the changes much more go compiler directed, vs relying on code inspection to feel confident the implementation is correct.

There are more spots where we do type dispatch, and special handling, but they are mostly ref vs not-ref related, and would matter when we introduce a `map[x]y` type.

Each commit in this PR is isolated, and meant to be reviewed by itself.