### PR TITLE
A solution for sums needing to be initialized at 0

### DIFF
--- a/computed_by_test.go
+++ b/computed_by_test.go
@@ -912,13 +912,13 @@ func (s *DbZuite) TestComputedBy_crossWs_updateOfChildCarriesToParent() {
 
 func (s *Zuite) TestComputedBy_computedByOnNewInstance() {
 	defs := MustNewDefinitions(strings.NewReader(`
-	worksheet sum_should_be_zeron_on_new {
+	worksheet sum_should_be_zero_on_new {
 		1:nums []number[0]
 		2:sum number[0] computed_by {
 			return sum(nums)
 		}
 	}`))
 
-	ws := defs.MustNewWorksheet("sum_should_be_zeron_on_new")
+	ws := defs.MustNewWorksheet("sum_should_be_zero_on_new")
 	require.Equal(s.T(), NewNumberFromInt(0), ws.MustGet("sum"))
 }

--- a/expressions.go
+++ b/expressions.go
@@ -83,10 +83,9 @@ func (e tSelector) selectors() []tSelector {
 }
 
 func (e tSelector) compute(ws *Worksheet) (Value, error) {
-	// TODO(pascal): raw get for internal use?
-	value, ok := ws.data[ws.def.fieldsByName[e[0]].index]
-	if !ok {
-		value = vUndefined
+	_, value, err := ws.get(e[0])
+	if err != nil {
+		return nil, err
 	}
 
 	// base case
@@ -343,6 +342,8 @@ var functions = map[string]struct {
 			return nil, err
 		}
 		switch v := arg.(type) {
+		case *Undefined:
+			return vUndefined, nil
 		case *Slice:
 			numType, ok := v.typ.elementType.(*NumberType)
 			if !ok {

--- a/values.go
+++ b/values.go
@@ -125,6 +125,10 @@ func NewNumberFromInt(num int) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+func NewNumberFromInt64(num int64) *Number {
+	return &Number{num, &NumberType{0}}
+}
+
 func NewNumberFromFloat64(num float64) *Number {
 	return MustNewValue(strconv.FormatFloat(num, 'f', -1, 64)).(*Number)
 }


### PR DESCRIPTION
We had the issue where the `sum` in the following worksheet

	worksheet sum_example {
		1:nums []number[0]
		2:sum number[0] computed_by {
			sum(nums)
		}
	}

would be `undefined` when initiliazed, and when the first number is appended to the `nums`, it would actually represent the sum of numbers.

However, we've seen in practice that we want the sum to be defined to `0` when initializing the worksheet, as this actually represents the initial state.

To achieve this, suggesting two changes:

1. Slice fields start empty (vs undefined). Currently, only appending and deleting from slices is allowed, and we're therefore already saying that slice fields are never undefined, rather empty. This change makes it concrete in the internals.

2. When creating a new instance of a worksheet, we trigger all `computed_by` at least once. Most of these will yield `undefined` on `undefined` inputs, but some like sums would actually yield a result. We've already seen cases of running `computed_by` during initialization to support the "signoff pattern" (see `TestSignoffPattern`), so this is a generalization which fits in the spirit of the framework.