### PR TITLE
Cleanup: using NewNumberFromXxx vs the general NewValue

### DIFF
--- a/clone.go
+++ b/clone.go
@@ -75,7 +75,7 @@ func (c *cloner) cloneWs(ws *Worksheet) *Worksheet {
 
 	dup := ws.def.newUninitializedWorksheet()
 	dup.data[indexId] = NewText(uuid.Must(uuid.NewV4()).String())
-	dup.data[indexVersion] = MustNewValue("1")
+	dup.data[indexVersion] = NewNumberFromInt(1)
 	c.mapping[ws.Id()] = dup.Id()
 	c.clones[dup.Id()] = dup
 

--- a/clone_test.go
+++ b/clone_test.go
@@ -28,7 +28,7 @@ type dup_me worksheet {
 func (s *Zuite) TestClone_simple() {
 	ws := s.cloneDefs.MustNewWorksheet("dup_me")
 	ws.MustSet("value", NewText("Mary had a little lamb"))
-	ws.data[indexVersion] = MustNewValue("666")
+	ws.data[indexVersion] = NewNumberFromInt(666)
 
 	dup := ws.Clone()
 	require.True(s.T(), ws != dup, "dup must be a different instance than ws")
@@ -37,7 +37,7 @@ func (s *Zuite) TestClone_simple() {
 	require.Len(s.T(), dup.orig, 0)
 	require.Equal(s.T(), map[int]Value{
 		indexId:      NewText(dup.Id()),
-		indexVersion: MustNewValue("1"),
+		indexVersion: NewNumberFromInt(1),
 		1:            NewText("Mary had a little lamb"),
 	}, dup.data)
 	require.Len(s.T(), dup.parents, 0)
@@ -62,12 +62,12 @@ func (s *Zuite) TestClone_withOneWsRef() {
 
 	require.Equal(s.T(), map[int]Value{
 		indexId:      NewText(dup1.Id()),
-		indexVersion: MustNewValue("1"),
+		indexVersion: NewNumberFromInt(1),
 		4:            dup2,
 	}, dup1.data)
 	require.Equal(s.T(), map[int]Value{
 		indexId:      NewText(dup2.Id()),
-		indexVersion: MustNewValue("1"),
+		indexVersion: NewNumberFromInt(1),
 	}, dup2.data)
 
 	require.Len(s.T(), dup1.parents, 0)
@@ -105,13 +105,13 @@ func (s *Zuite) TestClone_withTwoWsRefToSameWs() {
 
 	require.Equal(s.T(), map[int]Value{
 		indexId:      NewText(dup1.Id()),
-		indexVersion: MustNewValue("1"),
+		indexVersion: NewNumberFromInt(1),
 		4:            dup2,
 		5:            dup2,
 	}, dup1.data)
 	require.Equal(s.T(), map[int]Value{
 		indexId:      NewText(dup2.Id()),
-		indexVersion: MustNewValue("1"),
+		indexVersion: NewNumberFromInt(1),
 	}, dup2.data)
 
 	require.Len(s.T(), dup1.parents, 0)
@@ -129,12 +129,12 @@ func (s *Zuite) TestClone_withTwoWsRefToSameWs() {
 
 func (s *Zuite) TestClone_withSliceOfValues() {
 	ws := s.cloneDefs.MustNewWorksheet("dup_me")
-	ws.MustAppend("v_slice", MustNewValue("2"))
-	ws.MustAppend("v_slice", MustNewValue("3"))
-	ws.MustAppend("v_slice", MustNewValue("3"))
-	ws.MustAppend("v_slice", MustNewValue("5"))
-	ws.MustAppend("v_slice", MustNewValue("8"))
-	ws.MustAppend("v_slice", MustNewValue("13"))
+	ws.MustAppend("v_slice", NewNumberFromInt(2))
+	ws.MustAppend("v_slice", NewNumberFromInt(3))
+	ws.MustAppend("v_slice", NewNumberFromInt(3))
+	ws.MustAppend("v_slice", NewNumberFromInt(5))
+	ws.MustAppend("v_slice", NewNumberFromInt(8))
+	ws.MustAppend("v_slice", NewNumberFromInt(13))
 	ws.MustDel("v_slice", 2)
 	wsSlice := ws.data[2].(*Slice)
 
@@ -158,11 +158,11 @@ func (s *Zuite) TestClone_withSliceOfValues() {
 	require.Equal(s.T(), wsSlice.typ, dupSlice.typ)
 	require.Equal(s.T(), 5, dupSlice.lastRank)
 	require.Equal(s.T(), []sliceElement{
-		{1, MustNewValue("2")},
-		{2, MustNewValue("3")},
-		{3, MustNewValue("5")},
-		{4, MustNewValue("8")},
-		{5, MustNewValue("13")},
+		{1, NewNumberFromInt(2)},
+		{2, NewNumberFromInt(3)},
+		{3, NewNumberFromInt(5)},
+		{4, NewNumberFromInt(8)},
+		{5, NewNumberFromInt(13)},
 	}, dupSlice.elements)
 }
 

--- a/computed_by_test.go
+++ b/computed_by_test.go
@@ -258,7 +258,7 @@ func (s *Zuite) TestComputedBy_externalGood() {
 
 	require.False(s.T(), ws.MustIsSet("name"))
 
-	ws.MustSet("age", MustNewValue("73"))
+	ws.MustSet("age", NewNumberFromInt(73))
 	require.Equal(s.T(), `"Alice"`, ws.MustGet("name").String())
 }
 
@@ -288,7 +288,7 @@ func (s *Zuite) TestComputedBy_externalGoodComplicated() {
 
 	ws.MustSet("first_name", NewText("Alice"))
 	ws.MustSet("last_name", NewText("Maters"))
-	ws.MustSet("birth_year", MustNewValue("1945"))
+	ws.MustSet("birth_year", NewNumberFromInt(1945))
 	require.Equal(s.T(), `"Alice Maters"`, ws.MustGet("full_name").String())
 	require.Equal(s.T(), `73`, ws.MustGet("age").String())
 	require.Equal(s.T(), `"Alice Maters, age 73, born in 1945"`, ws.MustGet("bio").String())
@@ -303,7 +303,7 @@ func (s *Zuite) TestComputedBy_simpleExpressionsInWorksheet() {
 
 	ws := defs.MustNewWorksheet("simple")
 
-	ws.MustSet("age", MustNewValue("73"))
+	ws.MustSet("age", NewNumberFromInt(73))
 	require.Equal(s.T(), "75", ws.MustGet("age_plus_two").String())
 }
 
@@ -321,7 +321,7 @@ func (s *Zuite) TestComputedBy_cyclicEditsIfNoIdentCheck() {
 
 	ws := defs.MustNewWorksheet("cyclic_edits")
 
-	ws.MustSet("right", MustNewValue("true"))
+	ws.MustSet("right", NewBool(true))
 	require.Equal(s.T(), "true", ws.MustGet("right").String(), "right")
 	require.Equal(s.T(), "undefined", ws.MustGet("a").String(), "a")
 	require.Equal(s.T(), "undefined", ws.MustGet("b").String(), "b")
@@ -364,11 +364,11 @@ func (s *Zuite) TestComputedBy_simpleCrossWsExample() {
 	parent := s.defsCrossWs.MustNewWorksheet("parent")
 
 	child := s.defsCrossWs.MustNewWorksheet("child")
-	child.MustSet("amount", MustNewValue("1.11"))
+	child.MustSet("amount", NewNumberFromFloat64(1.11))
 	parent.MustSet("child", child)
 	require.Equal(s.T(), "1.11", parent.MustGet("child_amount").String())
 
-	child.MustSet("amount", MustNewValue("2.22"))
+	child.MustSet("amount", NewNumberFromFloat64(2.22))
 	require.Equal(s.T(), "2.22", parent.MustGet("child_amount").String())
 
 	parent.MustUnset("child")
@@ -386,7 +386,7 @@ func (p sumPlugin) Args() []string {
 
 func (p sumPlugin) Compute(values ...Value) Value {
 	slice := values[0].(*Slice)
-	sum := MustNewValue("0").(*Number)
+	sum := NewNumberFromInt(0)
 	for _, elem := range slice.Elements() {
 		if num, ok := elem.(*Number); ok {
 			sum = sum.Plus(num)
@@ -461,12 +461,12 @@ func (s *Zuite) TestComputedBy_crossWsThroughSliceExample() {
 	require.Equal(s.T(), "0", parent.MustGet("sum_child_amount").String())
 
 	child1 := s.defsCrossWsThroughSlice.MustNewWorksheet("child")
-	child1.MustSet("amount", MustNewValue("1.11"))
+	child1.MustSet("amount", NewNumberFromFloat64(1.11))
 	parent.MustAppend("children", child1)
 	require.Equal(s.T(), "1.11", parent.MustGet("sum_child_amount").String())
 
 	child2 := s.defsCrossWsThroughSlice.MustNewWorksheet("child")
-	child2.MustSet("amount", MustNewValue("2.22"))
+	child2.MustSet("amount", NewNumberFromFloat64(2.22))
 	parent.MustAppend("children", child2)
 	require.Equal(s.T(), "3.33", parent.MustGet("sum_child_amount").String())
 
@@ -490,7 +490,7 @@ func (s *Zuite) TestComputedBy_crossWs_parentsRefsPersistence() {
 		forciblySetId(parent, parentId)
 		child := s.defsCrossWs.MustNewWorksheet("child")
 		forciblySetId(child, childId)
-		child.MustSet("amount", MustNewValue("6.66"))
+		child.MustSet("amount", NewNumberFromFloat64(6.66))
 		parent.MustSet("child", child)
 		session := store.Open(tx)
 		_, err := session.Save(parent)
@@ -560,7 +560,7 @@ func (s *Zuite) TestComputedBy_crossWs_twoParentsOneChildRefsPersistence() {
 		forciblySetId(parent2, parent2Id)
 		child := s.defsCrossWs.MustNewWorksheet("child")
 		forciblySetId(child, childId)
-		child.MustSet("amount", MustNewValue("6.66"))
+		child.MustSet("amount", NewNumberFromFloat64(6.66))
 		parent1.MustSet("child", child)
 		parent2.MustSet("child", child)
 
@@ -625,7 +625,7 @@ func (s *Zuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 		forciblySetId(parent, parentId)
 		child1 := s.defsCrossWsThroughSlice.MustNewWorksheet("child")
 		forciblySetId(child1, child1Id)
-		child1.MustSet("amount", MustNewValue("6.66"))
+		child1.MustSet("amount", NewNumberFromFloat64(6.66))
 		parent.MustAppend("children", child1)
 		session := store.Open(tx)
 		_, err := session.Save(parent)
@@ -652,7 +652,7 @@ func (s *Zuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence1() {
 		}
 		child2 := s.defsCrossWsThroughSlice.MustNewWorksheet("child")
 		forciblySetId(child2, child2Id)
-		child2.MustSet("amount", MustNewValue("7.77"))
+		child2.MustSet("amount", NewNumberFromFloat64(7.77))
 		parent.MustAppend("children", child2)
 		_, err = session.Update(parent)
 		return err
@@ -710,7 +710,7 @@ func (s *Zuite) TestComputedBy_crossWs_parentWithSlicesRefsPersistence2() {
 
 		child := s.defsCrossWsThroughSlice.MustNewWorksheet("child")
 		forciblySetId(child, childId)
-		child.MustSet("amount", MustNewValue("6.66"))
+		child.MustSet("amount", NewNumberFromFloat64(6.66))
 
 		session := store.Open(tx)
 		if _, err := session.Save(parent); err != nil {
@@ -768,8 +768,8 @@ func (s *Zuite) TestComputedBy_crossWs_updateOfChildCarriesToParent() {
 		forciblySetId(parent, parentId)
 		forciblySetId(child1, child1Id)
 		forciblySetId(child2, child2Id)
-		child1.MustSet("amount", MustNewValue("6.66"))
-		child2.MustSet("amount", MustNewValue("7.77"))
+		child1.MustSet("amount", NewNumberFromFloat64(6.66))
+		child2.MustSet("amount", NewNumberFromFloat64(7.77))
 		parent.MustAppend("children", child1)
 		parent.MustAppend("children", child2)
 		childrenSliceId = parent.data[20].(*Slice).id
@@ -786,7 +786,7 @@ func (s *Zuite) TestComputedBy_crossWs_updateOfChildCarriesToParent() {
 		if err != nil {
 			return err
 		}
-		child2.MustSet("amount", MustNewValue("8.88"))
+		child2.MustSet("amount", NewNumberFromFloat64(8.88))
 		_, err = session.Update(child2)
 		return err
 	})

--- a/constrained_by_test.go
+++ b/constrained_by_test.go
@@ -14,7 +14,6 @@ package worksheets
 
 import (
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/stretchr/testify/require"
@@ -48,7 +47,7 @@ func (s *Zuite) TestWorksheet_constrainedByNonBoolExpression() {
 	ws := defs.MustNewWorksheet("constrained_non_bool_constrained_expression")
 
 	require.False(s.T(), ws.MustIsSet("some_field"))
-	err = ws.Set("some_field", MustNewValue("7"))
+	err = ws.Set("some_field", NewNumberFromInt(7))
 	require.Equal(s.T(), "7 not a valid value for constrained field some_field", err.Error())
 	require.False(s.T(), ws.MustIsSet("some_field"))
 }
@@ -77,7 +76,7 @@ func (fn perimeterAndAreaConstraints) Compute(values ...Value) Value {
 	}
 	switch t := values[2].(type) {
 	case *Number:
-		field_c = t.value
+		field_c = t.Round(ModeHalf, 2).value / 100
 	case *Undefined:
 		field_c = 0
 	}
@@ -117,7 +116,7 @@ func (fn hypotenuse) Compute(values ...Value) Value {
 		field_b = 0
 	}
 	c := math.Sqrt(float64(field_a*field_a + field_b*field_b))
-	hypotVal, _ := NewValue(strconv.FormatFloat(c, 'f', 0, 64))
+	hypotVal := NewNumberFromFloat64(c).Round(ModeHalf, 2)
 	return hypotVal
 }
 
@@ -143,8 +142,7 @@ func (fn area) Compute(values ...Value) Value {
 	case *Undefined:
 		return vUndefined
 	}
-	a := float64(field_a * field_b / 2)
-	areaVal, _ := NewValue(strconv.FormatFloat(a, 'f', 0, 64))
+	areaVal := NewNumberFromFloat64(float64(field_a * field_b / 2))
 	return areaVal
 }
 
@@ -173,18 +171,18 @@ func (s *Zuite) TestWorksheet_constrainedByAndComputedBy() {
 	ws := defs.MustNewWorksheet("constrained_and_computed")
 
 	require.False(s.T(), ws.MustIsSet("field_a"))
-	err = ws.Set("field_a", MustNewValue("28"))
+	err = ws.Set("field_a", NewNumberFromInt(28))
 	require.NoError(s.T(), err)
 
-	err = ws.Set("field_b", MustNewValue("90"))
+	err = ws.Set("field_b", NewNumberFromInt(90))
 	require.Equal(s.T(), "90 not a valid value for constrained field field_b", err.Error())
 
-	err = ws.Set("field_b", MustNewValue("21"))
+	err = ws.Set("field_b", NewNumberFromInt(21))
 	require.NoError(s.T(), err)
 
-	err = ws.Set("field_b", MustNewValue("1")) // too small in area
+	err = ws.Set("field_b", NewNumberFromInt(1)) // too small in area
 	require.Equal(s.T(), "1 not a valid value for constrained field field_b", err.Error())
 
-	err = ws.Set("field_b", MustNewValue("50")) // too long of perimiter
+	err = ws.Set("field_b", NewNumberFromInt(50)) // too long of perimiter
 	require.Equal(s.T(), "50 not a valid value for constrained field field_b", err.Error())
 }

--- a/dbstore.go
+++ b/dbstore.go
@@ -344,11 +344,18 @@ func (typ *TextType) dbReadValue(l *loader, value string) (Value, error) {
 }
 
 func (typ *BoolType) dbReadValue(l *loader, value string) (Value, error) {
-	return NewValue(value)
+	switch value {
+	case "true":
+		return NewBool(true), nil
+	case "false":
+		return NewBool(false), nil
+	default:
+		return nil, fmt.Errorf("unreadable value for bool %s", value)
+	}
 }
 
 func (typ *NumberType) dbReadValue(l *loader, value string) (Value, error) {
-	return NewValue(value)
+	return NewNumberFromString(value)
 }
 
 func (typ *SliceType) dbReadValue(l *loader, value string) (Value, error) {

--- a/dbstore_test.go
+++ b/dbstore_test.go
@@ -13,7 +13,6 @@
 package worksheets
 
 import (
-	"fmt"
 	"math"
 	"strings"
 	"time"
@@ -257,7 +256,7 @@ func (s *Zuite) TestUpdateUndefinedField() {
 		return err
 	})
 
-	err = ws.Set("age", MustNewValue("73"))
+	err = ws.Set("age", NewNumberFromInt(73))
 	require.NoError(s.T(), err)
 
 	s.MustRunTransaction(func(tx *runner.Tx) error {
@@ -272,7 +271,7 @@ func (s *Zuite) TestProperlyLoadUndefinedField() {
 	s.MustRunTransaction(func(tx *runner.Tx) error {
 		ws := s.defs.MustNewWorksheet("simple")
 		wsId = ws.Id()
-		ws.MustSet("age", MustNewValue("123456"))
+		ws.MustSet("age", NewNumberFromInt(123456))
 
 		session := s.store.Open(tx)
 		_, err := session.Save(ws)
@@ -468,7 +467,7 @@ func (s *Zuite) TestSignoffPattern() {
 	require.Equal(s.T(), "false", ws.MustGet("is_signedoff").String())
 
 	// worksheet is signed off
-	ws.MustSet("signoff_at", MustNewValue(fmt.Sprintf("%d", ws.Version())))
+	ws.MustSet("signoff_at", NewNumberFromInt(ws.Version()))
 	s.MustRunTransaction(func(tx *runner.Tx) error {
 		session := s.store.Open(tx)
 		_, err := session.SaveOrUpdate(ws)
@@ -489,7 +488,7 @@ func (s *Zuite) TestSignoffPattern() {
 
 	// worksheet is signed off again, except this time, the update will fail
 	// (due to a concurrent modification)
-	ws.MustSet("signoff_at", MustNewValue(fmt.Sprintf("%d", ws.Version())))
+	ws.MustSet("signoff_at", NewNumberFromInt(ws.Version()))
 	_, err := s.db.Exec("update worksheets set version = version + 1 where id = $1", ws.Id())
 	require.NoError(s.T(), err)
 

--- a/marshaling_test.go
+++ b/marshaling_test.go
@@ -26,8 +26,8 @@ func (s *Zuite) TestMarshaling_simple() {
 	forciblySetId(ws, "the-id")
 	ws.MustSet("text", NewText(`some text with " and stuff`))
 	ws.MustSet("bool", NewBool(true))
-	ws.MustSet("num_0", MustNewValue("123"))
-	ws.MustSet("num_2", MustNewValue("123.45"))
+	ws.MustSet("num_0", NewNumberFromInt(123))
+	ws.MustSet("num_2", NewNumberFromFloat64(123.45))
 	ws.MustSet("undefined", vUndefined)
 
 	expected := `{"the-id":{
@@ -345,30 +345,31 @@ func (s *Zuite) TestStructScan_convert() {
 	}{
 		{NewText("hello"), stringTyp, "hello"},
 		{NewBool(true), stringTyp, "true"},
-		{MustNewValue("123.45"), stringTyp, "123.45"},
+		{NewNumberFromFloat64(123.45), stringTyp, "123.45"},
 
 		{NewBool(true), boolTyp, true},
 
-		{MustNewValue("123"), intTyp, int(123)},
-		{MustNewValue("123"), int64Typ, int64(123)},
+		{NewNumberFromInt(123), intTyp, int(123)},
+		{NewNumberFromInt64(123), int64Typ, int64(123)},
 
-		{MustNewValue("123.45"), float32Typ, float32(123.45)},
-		{MustNewValue("123.45"), float64Typ, float64(123.45)},
+		{NewNumberFromFloat32(123.45), float32Typ, float32(123.45)},
+		{NewNumberFromFloat64(123.45), float64Typ, float64(123.45)},
 
-		{MustNewValue("127"), int8Typ, int8(127)},
-		{MustNewValue("-128"), int8Typ, int8(-128)},
-		{MustNewValue("32_767"), int16Typ, int16(32767)},
-		{MustNewValue("-32_768"), int16Typ, int16(-32768)},
-		{MustNewValue("2_147_483_647"), int32Typ, int32(2147483647)},
-		{MustNewValue("-2_147_483_648"), int32Typ, int32(-2147483648)},
-		{MustNewValue("9_223_372_036_854_775_807"), int64Typ, int64(9223372036854775807)},
-		{MustNewValue("-9_223_372_036_854_775_808"), int64Typ, int64(-9223372036854775808)},
+		{NewNumberFromInt8(127), int8Typ, int8(127)},
+		{NewNumberFromInt8(-128), int8Typ, int8(-128)},
+		{NewNumberFromInt16(32767), int16Typ, int16(32767)},
+		{NewNumberFromInt16(-32768), int16Typ, int16(-32768)},
+		{NewNumberFromInt32(2147483647), int32Typ, int32(2147483647)},
+		{NewNumberFromInt32(-2147483648), int32Typ, int32(-2147483648)},
+		{NewNumberFromInt64(9223372036854775807), int64Typ, int64(9223372036854775807)},
+		{NewNumberFromInt64(-9223372036854775808), int64Typ, int64(-9223372036854775808)},
 
-		{MustNewValue("255"), uint8Typ, uint8(255)},
-		{MustNewValue("65_535"), uint16Typ, uint16(65535)},
-		{MustNewValue("4_294_967_295"), uint32Typ, uint32(4294967295)},
+		{NewNumberFromUint(255), uintTyp, uint(255)},
+		{NewNumberFromUint8(255), uint8Typ, uint8(255)},
+		{NewNumberFromUint16(65535), uint16Typ, uint16(65535)},
+		{NewNumberFromUint32(4294967295), uint32Typ, uint32(4294967295)},
 		// TODO: See issue #29: support for arbitrary precision numbers
-		// {MustNewValue("18_446_744_073_709_551_615"), int64Typ, uint64(18446744073709551615)},
+		// {NewNumberFromUint64(18446744073709551615), uint64Typ, uint64(18446744073709551615)},
 	}
 	for _, ex := range cases {
 		ctx := convertCtx{
@@ -393,15 +394,15 @@ func (s *Zuite) TestStructScan_convertErrors() {
 		{NewBool(true), intTyp, "bool to int"},
 
 		{NewText("hello"), boolTyp, "text to bool"},
-		{MustNewValue("123.45"), boolTyp, "number[2] to bool"},
+		{NewNumberFromFloat64(123.45), boolTyp, "number[2] to bool"},
 
 		{NewText("hello"), intTyp, "text to int"},
 		{NewBool(true), intTyp, "bool to int"},
-		{MustNewValue("123.45"), intTyp, "number[2] to int"},
+		{NewNumberFromFloat64(123.45), intTyp, "number[2] to int"},
 
 		{NewText("hello"), int64Typ, "text to int64"},
 		{NewBool(true), int64Typ, "bool to int64"},
-		{MustNewValue("123.45"), int64Typ, "number[2] to int64"},
+		{NewNumberFromFloat64(123.45), int64Typ, "number[2] to int64"},
 
 		{NewText("hello"), float32Typ, "text to float32"},
 		{NewBool(true), float32Typ, "bool to float32"},
@@ -409,21 +410,21 @@ func (s *Zuite) TestStructScan_convertErrors() {
 		{NewText("hello"), float64Typ, "text to float64"},
 		{NewBool(true), float64Typ, "bool to float64"},
 
-		{MustNewValue("128"), int8Typ, "number[0] to int8, value out of range"},
-		{MustNewValue("-129"), int8Typ, "number[0] to int8, value out of range"},
-		{MustNewValue("32_768"), int16Typ, "number[0] to int16, value out of range"},
-		{MustNewValue("-32_769"), int16Typ, "number[0] to int16, value out of range"},
-		{MustNewValue("2_147_483_648"), int32Typ, "number[0] to int32, value out of range"},
-		{MustNewValue("-2_147_483_649"), int32Typ, "number[0] to int32, value out of range"},
+		{NewNumberFromInt(128), int8Typ, "number[0] to int8, value out of range"},
+		{NewNumberFromInt(-129), int8Typ, "number[0] to int8, value out of range"},
+		{NewNumberFromInt(32768), int16Typ, "number[0] to int16, value out of range"},
+		{NewNumberFromInt(-32769), int16Typ, "number[0] to int16, value out of range"},
+		{NewNumberFromInt(2147483648), int32Typ, "number[0] to int32, value out of range"},
+		{NewNumberFromInt(-2147483649), int32Typ, "number[0] to int32, value out of range"},
 		// TODO: See issue #29: support for arbitrary precision numbers
-		// {MustNewValue("9_223_372_036_854_775_808"), int64Typ, "number[0] to int64, value out of range"},
-		// {MustNewValue("-9_223_372_036_854_775_809"), int64Typ, "number[0] to int64, value out of range"},
+		// {MustParseLiteral("9_223_372_036_854_775_808"), int64Typ, "number[0] to int64, value out of range"},
+		// {MustParseLiteral("-9_223_372_036_854_775_809"), int64Typ, "number[0] to int64, value out of range"},
 
-		{MustNewValue("256"), uint8Typ, "number[0] to uint8, value out of range"},
-		{MustNewValue("65_536"), uint16Typ, "number[0] to uint16, value out of range"},
-		{MustNewValue("4_294_967_296"), uint32Typ, "number[0] to uint32, value out of range"},
+		{NewNumberFromInt(256), uint8Typ, "number[0] to uint8, value out of range"},
+		{NewNumberFromInt(65536), uint16Typ, "number[0] to uint16, value out of range"},
+		{NewNumberFromInt(4294967296), uint32Typ, "number[0] to uint32, value out of range"},
 		// TODO: See issue #29: support for arbitrary precision numbers
-		// {MustNewValue("18_446_744_073_709_551_616"), int64Typ, "number[0] to int64, value out of range"},
+		// {MustParseLiteral("18_446_744_073_709_551_616"), uint32Typ, "number[0] to int64, value out of range"},
 	}
 	for _, ex := range cases {
 		ctx := convertCtx{
@@ -433,6 +434,7 @@ func (s *Zuite) TestStructScan_convertErrors() {
 			destType:        ex.dest,
 		}
 		_, err := convert(ctx, ex.source)
-		assert.EqualError(s.T(), err, "field source to struct field Dest: cannot convert "+ex.expected)
+		assert.EqualErrorf(s.T(), err, "field source to struct field Dest: cannot convert "+ex.expected,
+			"converting %s to %s", ex.source, ex.dest)
 	}
 }

--- a/refs_test.go
+++ b/refs_test.go
@@ -123,7 +123,7 @@ func (s *Zuite) TestRefsSave_withDataInRefWorksheet() {
 	)
 	ws.MustSet("simple", simple)
 	simple.MustSet("name", alice)
-	simple.MustSet("age", MustNewValue("120"))
+	simple.MustSet("age", NewNumberFromInt(120))
 
 	// We forcibly set both worksheets' identifiers to have a known ordering
 	// when comparing the db state.

--- a/values.go
+++ b/values.go
@@ -141,8 +141,40 @@ func NewNumberFromInt(num int) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+func NewNumberFromInt8(num int8) *Number {
+	return &Number{int64(num), &NumberType{0}}
+}
+
+func NewNumberFromInt16(num int16) *Number {
+	return &Number{int64(num), &NumberType{0}}
+}
+
+func NewNumberFromInt32(num int32) *Number {
+	return &Number{int64(num), &NumberType{0}}
+}
+
 func NewNumberFromInt64(num int64) *Number {
 	return &Number{num, &NumberType{0}}
+}
+
+func NewNumberFromUint(num uint) *Number {
+	return &Number{int64(num), &NumberType{0}}
+}
+
+func NewNumberFromUint8(num uint8) *Number {
+	return &Number{int64(num), &NumberType{0}}
+}
+
+func NewNumberFromUint16(num uint16) *Number {
+	return &Number{int64(num), &NumberType{0}}
+}
+
+func NewNumberFromUint32(num uint32) *Number {
+	return &Number{int64(num), &NumberType{0}}
+}
+
+func NewNumberFromFloat32(num float32) *Number {
+	return NewNumberFromFloat64(float64(num))
 }
 
 func NewNumberFromFloat64(num float64) *Number {

--- a/values.go
+++ b/values.go
@@ -137,48 +137,76 @@ func (value *Undefined) String() string {
 	return "undefined"
 }
 
+// NewNumberFromString returns a new Number from a string representation.
+func NewNumberFromString(value string) (*Number, error) {
+	v, err := NewValue(value)
+	if err != nil {
+		return nil, err
+	}
+	n, ok := v.(*Number)
+	if !ok {
+		return nil, fmt.Errorf("not a number %s", value)
+	}
+	return n, nil
+}
+
+// NewNumberFromInt returns a new Number from int.
 func NewNumberFromInt(num int) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromInt8 returns a new Number from int8.
 func NewNumberFromInt8(num int8) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromInt16 returns a new Number from int16.
 func NewNumberFromInt16(num int16) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromInt32 returns a new Number from int32.
 func NewNumberFromInt32(num int32) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromInt64 returns a new Number from int64.
 func NewNumberFromInt64(num int64) *Number {
 	return &Number{num, &NumberType{0}}
 }
 
+// NewNumberFromUint returns a new Number from uint.
 func NewNumberFromUint(num uint) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromUint8 returns a new Number from uint8.
 func NewNumberFromUint8(num uint8) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromUint16 returns a new Number from uint16.
 func NewNumberFromUint16(num uint16) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromUint32 returns a new Number from uint32.
 func NewNumberFromUint32(num uint32) *Number {
 	return &Number{int64(num), &NumberType{0}}
 }
 
+// NewNumberFromFloat32 returns a new Number from float32.
 func NewNumberFromFloat32(num float32) *Number {
 	return NewNumberFromFloat64(float64(num))
 }
 
+// NewNumberFromFloat64 returns a new Number from float64.
 func NewNumberFromFloat64(num float64) *Number {
-	return MustNewValue(strconv.FormatFloat(num, 'f', -1, 64)).(*Number)
+	value, err := NewNumberFromString(strconv.FormatFloat(num, 'f', -1, 64))
+	if err != nil {
+		panic(fmt.Sprintf("unexpected %s", err))
+	}
+	return value
 }
 
 func (value *Number) Type() Type {

--- a/values_test.go
+++ b/values_test.go
@@ -19,7 +19,7 @@ import (
 func (s *Zuite) TestValueString() {
 	ws := s.defs.MustNewWorksheet("simple")
 	ws.MustSet("name", alice)
-	ws.MustSet("age", MustNewValue("73"))
+	ws.MustSet("age", NewNumberFromInt(73))
 
 	cases := map[Value]string{
 		vUndefined: "undefined",
@@ -60,16 +60,16 @@ func (s *Zuite) TestValueEqual() {
 			NewUndefined(),
 		},
 		{
-			MustNewValue("1"),
-			MustNewValue("1"),
-			MustNewValue("1.0"),
-			MustNewValue("1.000"),
+			&Number{1, &NumberType{0}},
+			&Number{1, &NumberType{0}},
+			&Number{10, &NumberType{1}},
+			&Number{1000, &NumberType{3}},
 		},
 		{
-			MustNewValue("0"),
-			MustNewValue("0"),
-			MustNewValue("-0"),
-			MustNewValue("0.000"),
+			&Number{0, &NumberType{0}},
+			&Number{0, &NumberType{1}},
+			&Number{0, &NumberType{2}},
+			&Number{0, &NumberType{3}},
 		},
 		{
 			NewText("Alice"),
@@ -119,167 +119,176 @@ func (s *Zuite) TestValueEqual() {
 
 func (s *Zuite) TestNumber_Plus() {
 	cases := []struct {
-		left, right, expected *Number
+		left, right *Number
+		expected    string
 	}{
 		{
-			left:     MustNewValue("2").(*Number),
-			right:    MustNewValue("3").(*Number),
-			expected: MustNewValue("5").(*Number),
+			left:     NewNumberFromInt(2),
+			right:    NewNumberFromInt(3),
+			expected: "5",
 		},
 		{
-			left:     MustNewValue("2.0").(*Number),
-			right:    MustNewValue("3").(*Number),
-			expected: MustNewValue("5.0").(*Number),
+			left:     NewNumberFromInt(2).Round(ModeHalf, 1),
+			right:    NewNumberFromInt(3),
+			expected: "5.0",
 		},
 		{
-			left:     MustNewValue("2.0").(*Number),
-			right:    MustNewValue("3.0").(*Number),
-			expected: MustNewValue("5.0").(*Number),
+			left:     NewNumberFromInt(2).Round(ModeHalf, 1),
+			right:    NewNumberFromInt(3).Round(ModeHalf, 1),
+			expected: "5.0",
 		},
 	}
 	for _, ex := range cases {
 		actual := ex.left.Plus(ex.right)
-		assert.Equal(s.T(), ex.expected, actual, "%s + %s", ex.left, ex.right)
+		assert.Equal(s.T(), ex.expected, actual.String(), "%s + %s", ex.left, ex.right)
 
 		actual = ex.right.Plus(ex.left)
-		assert.Equal(s.T(), ex.expected, actual, "%s + %s", ex.right, ex.left)
+		assert.Equal(s.T(), ex.expected, actual.String(), "%s + %s", ex.right, ex.left)
 	}
 }
 
 func (s *Zuite) TestNumber_Minus() {
 	cases := []struct {
-		left, right, expected *Number
+		left, right *Number
+		expected    string
 	}{
 		{
-			left:     MustNewValue("2").(*Number),
-			right:    MustNewValue("3").(*Number),
-			expected: MustNewValue("-1").(*Number),
+			left:     NewNumberFromInt(2),
+			right:    NewNumberFromInt(3),
+			expected: "-1",
 		},
 		{
-			left:     MustNewValue("2.0").(*Number),
-			right:    MustNewValue("3").(*Number),
-			expected: MustNewValue("-1.0").(*Number),
+			left:     NewNumberFromInt(2).Round(ModeHalf, 1),
+			right:    NewNumberFromInt(3),
+			expected: "-1.0",
 		},
 		{
-			left:     MustNewValue("2.0").(*Number),
-			right:    MustNewValue("3.0").(*Number),
-			expected: MustNewValue("-1.0").(*Number),
+			left:     NewNumberFromInt(2).Round(ModeHalf, 1),
+			right:    NewNumberFromInt(3).Round(ModeHalf, 1),
+			expected: "-1.0",
 		},
 	}
 	for _, ex := range cases {
 		actual := ex.left.Minus(ex.right)
-		assert.Equal(s.T(), ex.expected, actual, "%s + %s", ex.left, ex.right)
+		assert.Equal(s.T(), ex.expected, actual.String(), "%s + %s", ex.left, ex.right)
 	}
 }
 
 func (s *Zuite) TestNumber_Mult() {
 	cases := []struct {
-		left, right, expected *Number
+		left, right *Number
+		expected    string
 	}{
 		{
-			left:     MustNewValue("2").(*Number),
-			right:    MustNewValue("3").(*Number),
-			expected: MustNewValue("6").(*Number),
+			left:     NewNumberFromInt(2),
+			right:    NewNumberFromInt(3),
+			expected: "6",
 		},
 		{
-			left:     MustNewValue("2.0").(*Number),
-			right:    MustNewValue("3").(*Number),
-			expected: MustNewValue("6.0").(*Number),
+			left:     NewNumberFromInt(2).Round(ModeHalf, 1),
+			right:    NewNumberFromInt(3),
+			expected: "6.0",
 		},
 		{
-			left:     MustNewValue("2.0").(*Number),
-			right:    MustNewValue("3.0").(*Number),
-			expected: MustNewValue("6.00").(*Number),
+			left:     NewNumberFromInt(2).Round(ModeHalf, 1),
+			right:    NewNumberFromInt(3).Round(ModeHalf, 1),
+			expected: "6.00",
 		},
 	}
 	for _, ex := range cases {
 		actual := ex.left.Mult(ex.right)
-		assert.Equal(s.T(), ex.expected, actual, "%s + %s", ex.left, ex.right)
+		assert.Equal(s.T(), ex.expected, actual.String(), "%s + %s", ex.left, ex.right)
 
 		actual = ex.right.Mult(ex.left)
-		assert.Equal(s.T(), ex.expected, actual, "%s + %s", ex.right, ex.left)
+		assert.Equal(s.T(), ex.expected, actual.String(), "%s + %s", ex.right, ex.left)
 	}
 }
 
 func (s *Zuite) TestNumber_Round() {
 	cases := []struct {
-		value, expected *Number
-		round           *tRound
+		value    *Number
+		round    *tRound
+		expected string
 	}{
 		// down
 		{
-			value:    MustNewValue("2.34").(*Number),
+			value:    NewNumberFromFloat64(2.34),
 			round:    &tRound{"down", 2},
-			expected: MustNewValue("2.34").(*Number),
+			expected: "2.34",
 		},
 		{
-			value:    MustNewValue("2.34").(*Number),
+			value:    NewNumberFromFloat64(2.34),
 			round:    &tRound{"down", 3},
-			expected: MustNewValue("2.340").(*Number),
+			expected: "2.340",
 		},
 		{
-			value:    MustNewValue("2.34").(*Number),
+			value:    NewNumberFromFloat64(2.34),
 			round:    &tRound{"down", 1},
-			expected: MustNewValue("2.3").(*Number),
+			expected: "2.3",
 		},
 
 		// up
 		{
-			value:    MustNewValue("2.34").(*Number),
+			value:    NewNumberFromFloat64(2.34),
 			round:    &tRound{"up", 1},
-			expected: MustNewValue("2.4").(*Number),
+			expected: "2.4",
 		},
 		{
-			value:    MustNewValue("2.00").(*Number),
+			value:    &Number{2, &NumberType{0}},
 			round:    &tRound{"up", 1},
-			expected: MustNewValue("2.0").(*Number),
+			expected: "2.0",
+		},
+		{
+			value:    &Number{200, &NumberType{2}},
+			round:    &tRound{"up", 1},
+			expected: "2.0",
 		},
 
 		// half
 		{
-			value:    MustNewValue("2.34").(*Number),
+			value:    NewNumberFromFloat64(2.34),
 			round:    &tRound{"half", 1},
-			expected: MustNewValue("2.3").(*Number),
+			expected: "2.3",
 		},
 		{
-			value:    MustNewValue("2.35").(*Number),
+			value:    NewNumberFromFloat64(2.35),
 			round:    &tRound{"half", 1},
-			expected: MustNewValue("2.4").(*Number),
+			expected: "2.4",
 		},
 		{
-			value:    MustNewValue("-2.34").(*Number),
+			value:    NewNumberFromFloat64(-2.34),
 			round:    &tRound{"half", 1},
-			expected: MustNewValue("-2.3").(*Number),
+			expected: "-2.3",
 		},
 		{
-			value:    MustNewValue("-2.35").(*Number),
+			value:    NewNumberFromFloat64(-2.35),
 			round:    &tRound{"half", 1},
-			expected: MustNewValue("-2.4").(*Number),
+			expected: "-2.4",
 		},
 		{
-			value:    MustNewValue("2.304").(*Number),
+			value:    NewNumberFromFloat64(2.304),
 			round:    &tRound{"half", 2},
-			expected: MustNewValue("2.30").(*Number),
+			expected: "2.30",
 		},
 		{
-			value:    MustNewValue("2.305").(*Number),
+			value:    NewNumberFromFloat64(2.305),
 			round:    &tRound{"half", 2},
-			expected: MustNewValue("2.31").(*Number),
+			expected: "2.31",
 		},
 		{
-			value:    MustNewValue("-2.304").(*Number),
+			value:    NewNumberFromFloat64(-2.304),
 			round:    &tRound{"half", 2},
-			expected: MustNewValue("-2.30").(*Number),
+			expected: "-2.30",
 		},
 		{
-			value:    MustNewValue("-2.305").(*Number),
+			value:    NewNumberFromFloat64(-2.305),
 			round:    &tRound{"half", 2},
-			expected: MustNewValue("-2.31").(*Number),
+			expected: "-2.31",
 		},
 	}
 	for _, ex := range cases {
 		actual := ex.value.Round(ex.round.mode, ex.round.scale)
-		assert.Equal(s.T(), ex.expected, actual,
+		assert.Equal(s.T(), ex.expected, actual.String(),
 			"%s round %s %d should equal %s",
 			ex.value, ex.round.mode, ex.round.scale, ex.expected)
 	}
@@ -287,133 +296,134 @@ func (s *Zuite) TestNumber_Round() {
 
 func (s *Zuite) TestNumber_Div() {
 	cases := []struct {
-		left, right, expected *Number
-		round                 *tRound
+		left, right *Number
+		round       *tRound
+		expected    string
 	}{
 		{
-			left:     MustNewValue("8").(*Number),
-			right:    MustNewValue("2").(*Number),
-			expected: MustNewValue("4.0").(*Number),
+			left:     NewNumberFromInt(8),
+			right:    NewNumberFromInt(2),
+			expected: "4.0",
 			round:    &tRound{"up", 1},
 		},
 		{
-			left:     MustNewValue("8").(*Number),
-			right:    MustNewValue("2").(*Number),
-			expected: MustNewValue("4.00").(*Number),
+			left:     NewNumberFromInt(8),
+			right:    NewNumberFromInt(2),
+			expected: "4.00",
 			round:    &tRound{"up", 2},
 		},
 		{
-			left:     MustNewValue("1").(*Number),
-			right:    MustNewValue("7").(*Number),
-			expected: MustNewValue("0.1").(*Number),
+			left:     NewNumberFromInt(1),
+			right:    NewNumberFromInt(7),
+			expected: "0.1",
 			round:    &tRound{"down", 1},
 		},
 		{
-			left:     MustNewValue("1").(*Number),
-			right:    MustNewValue("7").(*Number),
-			expected: MustNewValue("0.2").(*Number),
+			left:     NewNumberFromInt(1),
+			right:    NewNumberFromInt(7),
+			expected: "0.2",
 			round:    &tRound{"up", 1},
 		},
 		{
-			left:     MustNewValue("1").(*Number),
-			right:    MustNewValue("7").(*Number),
-			expected: MustNewValue("0.14").(*Number),
+			left:     NewNumberFromInt(1),
+			right:    NewNumberFromInt(7),
+			expected: "0.14",
 			round:    &tRound{"down", 2},
 		},
 		{
-			left:     MustNewValue("1").(*Number),
-			right:    MustNewValue("7").(*Number),
-			expected: MustNewValue("0.15").(*Number),
+			left:     NewNumberFromInt(1),
+			right:    NewNumberFromInt(7),
+			expected: "0.15",
 			round:    &tRound{"up", 2},
 		},
 		{
-			left:     MustNewValue("7").(*Number),
-			right:    MustNewValue("1.23").(*Number),
-			expected: MustNewValue("5.691").(*Number),
+			left:     NewNumberFromInt(7),
+			right:    NewNumberFromFloat64(1.23),
+			expected: "5.691",
 			round:    &tRound{"down", 3},
 		},
 		{
-			left:     MustNewValue("7").(*Number),
-			right:    MustNewValue("1.23").(*Number),
-			expected: MustNewValue("5.691").(*Number),
+			left:     NewNumberFromInt(7),
+			right:    NewNumberFromFloat64(1.23),
+			expected: "5.691",
 			round:    &tRound{"up", 3},
 		},
 		{
-			left:     MustNewValue("7").(*Number),
-			right:    MustNewValue("1.23").(*Number),
-			expected: MustNewValue("5.6910").(*Number),
+			left:     NewNumberFromInt(7),
+			right:    NewNumberFromFloat64(1.23),
+			expected: "5.6910",
 			round:    &tRound{"down", 4},
 		},
 		{
-			left:     MustNewValue("7").(*Number),
-			right:    MustNewValue("1.23").(*Number),
-			expected: MustNewValue("5.6911").(*Number),
+			left:     NewNumberFromInt(7),
+			right:    NewNumberFromFloat64(1.23),
+			expected: "5.6911",
 			round:    &tRound{"up", 4},
 		},
 		{
-			left:     MustNewValue("7").(*Number),
-			right:    MustNewValue("1.23").(*Number),
-			expected: MustNewValue("5.69105").(*Number),
+			left:     NewNumberFromInt(7),
+			right:    NewNumberFromFloat64(1.23),
+			expected: "5.69105",
 			round:    &tRound{"down", 5},
 		},
 		{
-			left:     MustNewValue("7").(*Number),
-			right:    MustNewValue("1.23").(*Number),
-			expected: MustNewValue("5.69106").(*Number),
+			left:     NewNumberFromInt(7),
+			right:    NewNumberFromFloat64(1.23),
+			expected: "5.69106",
 			round:    &tRound{"up", 5},
 		},
 		{
-			left:     MustNewValue("7.777").(*Number),
-			right:    MustNewValue("1.6").(*Number),
-			expected: MustNewValue("4").(*Number),
+			left:     NewNumberFromFloat64(7.777),
+			right:    NewNumberFromFloat64(1.6),
+			expected: "4",
 			round:    &tRound{"down", 0},
 		},
 		{
-			left:     MustNewValue("7.777").(*Number),
-			right:    MustNewValue("1.6").(*Number),
-			expected: MustNewValue("5").(*Number),
+			left:     NewNumberFromFloat64(7.777),
+			right:    NewNumberFromFloat64(1.6),
+			expected: "5",
 			round:    &tRound{"up", 0},
 		},
 		{
-			left:     MustNewValue("7.777").(*Number),
-			right:    MustNewValue("1.6").(*Number),
-			expected: MustNewValue("4.8").(*Number),
+			left:     NewNumberFromFloat64(7.777),
+			right:    NewNumberFromFloat64(1.6),
+			expected: "4.8",
 			round:    &tRound{"down", 1},
 		},
 		{
-			left:     MustNewValue("7.777").(*Number),
-			right:    MustNewValue("1.6").(*Number),
-			expected: MustNewValue("4.9").(*Number),
+			left:     NewNumberFromFloat64(7.777),
+			right:    NewNumberFromFloat64(1.6),
+			expected: "4.9",
 			round:    &tRound{"up", 1},
 		},
 		{
-			left:     MustNewValue("9.999999").(*Number),
-			right:    MustNewValue("1").(*Number),
-			expected: MustNewValue("9").(*Number),
+			left:     NewNumberFromFloat64(9.999999),
+			right:    NewNumberFromInt(1),
+			expected: "9",
 			round:    &tRound{"down", 0},
 		},
 		{
-			left:     MustNewValue("9.999999").(*Number),
-			right:    MustNewValue("1").(*Number),
-			expected: MustNewValue("10").(*Number),
+			left:     NewNumberFromFloat64(9.999999),
+			right:    NewNumberFromInt(1),
+			expected: "10",
 			round:    &tRound{"up", 0},
 		},
 		{
-			left:     MustNewValue("7").(*Number),
-			right:    MustNewValue("2.22").(*Number),
-			expected: MustNewValue("3.1532").(*Number),
+			left:     NewNumberFromInt(7),
+			right:    NewNumberFromFloat64(2.22),
+			expected: "3.1532",
 			round:    &tRound{"half", 4},
 		},
 		{
-			left:     MustNewValue("-7").(*Number),
-			right:    MustNewValue("2.22").(*Number),
-			expected: MustNewValue("-3.1532").(*Number),
+			left:     NewNumberFromInt(-7),
+			right:    NewNumberFromFloat64(2.22),
+			expected: "-3.1532",
 			round:    &tRound{"half", 4},
 		},
 	}
 	for _, ex := range cases {
 		actual := ex.left.Div(ex.right, ex.round.mode, ex.round.scale)
-		assert.Equal(s.T(), ex.expected, actual,
+		assert.Equal(s.T(), ex.expected, actual.String(),
 			"%s / %s round %s %d should equal %s",
 			ex.left, ex.right, ex.round.mode, ex.round.scale, ex.expected)
 	}

--- a/worksheets.go
+++ b/worksheets.go
@@ -15,7 +15,6 @@ package worksheets
 import (
 	"fmt"
 	"io"
-	"strconv"
 
 	"github.com/satori/go.uuid"
 )
@@ -319,7 +318,7 @@ func (defs *Definitions) NewWorksheet(name string) (*Worksheet, error) {
 	}
 
 	// version
-	if err := ws.Set("version", MustNewValue(strconv.Itoa(1))); err != nil {
+	if err := ws.Set("version", NewNumberFromInt(1)); err != nil {
 		panic(fmt.Sprintf("unexpected %s", err))
 	}
 

--- a/worksheets_test.go
+++ b/worksheets_test.go
@@ -292,7 +292,7 @@ func (s *Zuite) TestWorksheet_diff() {
 		},
 		indexVersion: change{
 			before: vUndefined,
-			after:  MustNewValue("1"),
+			after:  NewNumberFromInt(1),
 		},
 	}, ws.diff())
 
@@ -308,7 +308,7 @@ func (s *Zuite) TestWorksheet_diff() {
 		},
 		indexVersion: change{
 			before: vUndefined,
-			after:  MustNewValue("1"),
+			after:  NewNumberFromInt(1),
 		},
 		1: change{
 			before: vUndefined,
@@ -327,7 +327,7 @@ func (s *Zuite) TestWorksheet_diff() {
 		},
 		indexVersion: change{
 			before: vUndefined,
-			after:  MustNewValue("1"),
+			after:  NewNumberFromInt(1),
 		},
 		1: change{
 			before: vUndefined,
@@ -348,7 +348,7 @@ func (s *Zuite) TestWorksheet_diff() {
 		},
 		indexVersion: change{
 			before: vUndefined,
-			after:  MustNewValue("1"),
+			after:  NewNumberFromInt(1),
 		},
 		1: change{
 			before: bob,


### PR DESCRIPTION
Went from 219 uses down to 11 uses.

Next up, rename `NewValue` to `ParseLiteral`!