### PR TITLE
Allow fields to be deprecated

### DIFF
--- a/dbstore.go
+++ b/dbstore.go
@@ -258,7 +258,7 @@ func (l *loader) loadWorksheet(id string) (*Worksheet, error) {
 		// field
 		field, ok := ws.def.fieldsByIndex[index]
 		if !ok {
-			return nil, fmt.Errorf("unknown value with field index %d", index)
+			continue // skip deprecated fields
 		}
 
 		// load, and potentially defer hydration of value

--- a/dbstore_test.go
+++ b/dbstore_test.go
@@ -514,30 +514,30 @@ func (s *DbZuite) TestDeprecatedField() {
 	}`))
 
 	store := NewStore(defs)
+	var id string
 
-	ws := defs.MustNewWorksheet("some_worksheet")
-	ws.MustSet("field_one", NewText("one"))
-	ws.MustSet("field_two", NewText("two"))
-	ws.MustSet("field_three", NewText("three"))
-	var err error
 	s.MustRunTransaction(func(tx *runner.Tx) error {
-		session := store.Open(tx)
-		_, err = session.SaveOrUpdate(ws)
-		return nil
-	})
-	require.NoError(s.T(), err)
+		ws := defs.MustNewWorksheet("some_worksheet")
+		ws.MustSet("field_one", NewText("one"))
+		ws.MustSet("field_two", NewText("two"))
+		ws.MustSet("field_three", NewText("three"))
 
+		id = ws.Id()
+		session := store.Open(tx)
+		_, err := session.SaveOrUpdate(ws)
+		return err
+	})
+
+	// update definition
 	defs = MustNewDefinitions(strings.NewReader(`worksheet some_worksheet {
 		1:field_one text
 		3:field_three text
 	}`))
 	store = NewStore(defs)
 
-	var wsFromStore *Worksheet
 	s.MustRunTransaction(func(tx *runner.Tx) error {
 		session := store.Open(tx)
-		wsFromStore, err = session.Load(ws.Id())
+		_, err := session.Load(id)
 		return err
 	})
-	require.NoError(s.T(), err)
 }


### PR DESCRIPTION
Right now, removing a field from a worksheet definition causes issues if that field exists in the db. We should be allowed to deprecate fields, and therefore shouldn't return an error when a field exists in the db but not in our definition.
