### PR TITLE
Give ws stringer a way to break cycles.

### DIFF
--- a/testutil_test.go
+++ b/testutil_test.go
@@ -69,6 +69,14 @@ type with_refs worksheet {
 
 type with_refs_and_cycles worksheet {
 	404:point_to_me with_refs_and_cycles
+}
+
+type ping worksheet {
+	123:point_to_pong         pong
+}
+
+type pong worksheet {
+	321:point_to_ping         ping
 }`
 
 func forciblySetId(ws *Worksheet, id string) {

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -73,7 +73,7 @@ type with_refs_and_cycles worksheet {
 
 type ping worksheet {
 	123:point_to_pong pong
-    124:slice_of_ping []ping
+	124:slice_of_ping []ping
 }
 
 type pong worksheet {

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -72,11 +72,12 @@ type with_refs_and_cycles worksheet {
 }
 
 type ping worksheet {
-	123:point_to_pong         pong
+	123:point_to_pong pong
+    124:slice_of_ping []ping
 }
 
 type pong worksheet {
-	321:point_to_ping         ping
+	321:point_to_ping ping
 }`
 
 func forciblySetId(ws *Worksheet, id string) {

--- a/values.go
+++ b/values.go
@@ -562,7 +562,7 @@ func (ws *Worksheet) String() string {
 
 func (ws *Worksheet) stringerHelper(seen map[string]bool) string {
 	if _, ok := seen[ws.Id()]; ok {
-		return "<ref_to_seen_worksheet>"
+		return "<#ref>"
 	}
 	seen[ws.Id()] = true
 	fieldNames := make([]string, 0, len(ws.data)-2)

--- a/values.go
+++ b/values.go
@@ -530,13 +530,18 @@ func (value *Slice) Equal(that Value) bool {
 }
 
 func (value *Slice) String() string {
+	seen := make(map[string]bool)
+	return value.stringerHelper(seen)
+}
+
+func (value *Slice) stringerHelper(seen map[string]bool) string {
 	var buffer bytes.Buffer
 	buffer.WriteRune('[')
 	for i, element := range value.elements {
 		if i != 0 {
 			buffer.WriteRune(' ')
 		}
-		buffer.WriteString(element.value.String())
+		buffer.WriteString(stringerHelperSwitch(seen, element.value))
 	}
 	buffer.WriteRune(']')
 	return buffer.String()
@@ -551,6 +556,15 @@ func (ws *Worksheet) Equal(that Value) bool {
 }
 
 func (ws *Worksheet) String() string {
+	seen := make(map[string]bool)
+	return stringerHelperSwitch(seen, ws)
+}
+
+func (ws *Worksheet) stringerHelper(seen map[string]bool) string {
+	if _, ok := seen[ws.Id()]; ok {
+		return "<ref_to_seen_worksheet>"
+	}
+	seen[ws.Id()] = true
 	fieldNames := make([]string, 0, len(ws.data)-2)
 	for index := range ws.data {
 		if index != indexId && index != indexVersion {
@@ -569,8 +583,19 @@ func (ws *Worksheet) String() string {
 		}
 		buffer.WriteString(fieldName)
 		buffer.WriteRune(':')
-		buffer.WriteString(value.String())
+		buffer.WriteString(stringerHelperSwitch(seen, value))
 	}
 	buffer.WriteRune(']')
 	return buffer.String()
+}
+
+func stringerHelperSwitch(seen map[string]bool, v Value) string {
+	switch typedVal := v.(type) {
+	case *Worksheet:
+		return typedVal.stringerHelper(seen)
+	case *Slice:
+		return typedVal.stringerHelper(seen)
+	default:
+		return v.String()
+	}
 }

--- a/values_test.go
+++ b/values_test.go
@@ -21,6 +21,12 @@ func (s *Zuite) TestValueString() {
 	ws.MustSet("name", alice)
 	ws.MustSet("age", NewNumberFromInt(73))
 
+	// cycle
+	ping := s.defs.MustNewWorksheet("ping")
+	pong := s.defs.MustNewWorksheet("pong")
+	ping.MustSet("point_to_pong", pong)
+	pong.MustSet("point_to_ping", ping)
+
 	cases := map[Value]string{
 		vUndefined: "undefined",
 
@@ -46,6 +52,8 @@ func (s *Zuite) TestValueString() {
 		}}: "[true false]",
 
 		ws: `worksheet[age:73 name:"Alice"]`,
+
+		ping: `worksheet[point_to_pong:worksheet[point_to_ping:<ref_to_seen_worksheet>]]`,
 	}
 	for value, expected := range cases {
 		assert.Equal(s.T(), expected, value.String())

--- a/values_test.go
+++ b/values_test.go
@@ -27,6 +27,10 @@ func (s *Zuite) TestValueString() {
 	ping.MustSet("point_to_pong", pong)
 	pong.MustSet("point_to_ping", ping)
 
+	// slice cycle
+	pingSelf := s.defs.MustNewWorksheet("ping")
+	pingSelf.MustAppend("slice_of_ping", pingSelf)
+
 	cases := map[Value]string{
 		vUndefined: "undefined",
 
@@ -54,6 +58,7 @@ func (s *Zuite) TestValueString() {
 		ws: `worksheet[age:73 name:"Alice"]`,
 
 		ping: `worksheet[point_to_pong:worksheet[point_to_ping:<#ref>]]`,
+		pingSelf: `worksheet[slice_of_ping:[<#ref>]]`,
 	}
 	for value, expected := range cases {
 		assert.Equal(s.T(), expected, value.String())

--- a/values_test.go
+++ b/values_test.go
@@ -53,7 +53,7 @@ func (s *Zuite) TestValueString() {
 
 		ws: `worksheet[age:73 name:"Alice"]`,
 
-		ping: `worksheet[point_to_pong:worksheet[point_to_ping:<ref_to_seen_worksheet>]]`,
+		ping: `worksheet[point_to_pong:worksheet[point_to_ping:<#ref>]]`,
 	}
 	for value, expected := range cases {
 		assert.Equal(s.T(), expected, value.String())

--- a/values_test.go
+++ b/values_test.go
@@ -57,7 +57,7 @@ func (s *Zuite) TestValueString() {
 
 		ws: `worksheet[age:73 name:"Alice"]`,
 
-		ping: `worksheet[point_to_pong:worksheet[point_to_ping:<#ref>]]`,
+		ping:     `worksheet[point_to_pong:worksheet[point_to_ping:<#ref>]]`,
 		pingSelf: `worksheet[slice_of_ping:[<#ref>]]`,
 	}
 	for value, expected := range cases {


### PR DESCRIPTION
Testing https://github.com/helloeave/worksheets/pull/115 I found that printing out worksheets with cycles was not working.

Open to suggestions for the format for refs already seen. Currently it prints out <ref_to_seen_worksheet>.