### PR TITLE
Implement dbReadValue for enum types

### DIFF
--- a/dbstore.go
+++ b/dbstore.go
@@ -391,7 +391,7 @@ func (typ *Definition) dbReadValue(l *loader, value string) (Value, error) {
 }
 
 func (typ *EnumType) dbReadValue(l *loader, value string) (Value, error) {
-	panic("implement me")
+	return (&TextType{}).dbReadValue(l, value)
 }
 
 func (l *loader) nextSlicesToHydrate() map[string]*Slice {


### PR DESCRIPTION
Delegating to text type, since we're storing enum typed fields as text.