### PR TITLE
Adding min and max (and slice)

### DIFF
--- a/expressions.go
+++ b/expressions.go
@@ -518,8 +518,8 @@ type foldNumbers interface {
 	result() Value
 }
 
-func rFoldNumbers(f foldNumbers, args *fnArgs, min int) (Value, error) {
-	if err := args.checkMinArgsNum(min); err != nil {
+func rFoldNumbers(f foldNumbers, args *fnArgs, minArgs int) (Value, error) {
+	if err := args.checkMinArgsNum(minArgs); err != nil {
 		return nil, err
 	}
 	for i := 0; i < args.num(); i++ {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -241,6 +241,7 @@ func (s *Zuite) TestRuntime_parseAndEvalExprExpectingFailure() {
 		`slice()`:          `slice: at least 1 argument(s) expected but none found`,
 		`slice(undefined)`: `slice: unable to infer slice type, only undefined values encountered`,
 		`slice(1, "one")`:  `slice: cannot mix incompatible types number[0] and text in slice`,
+		`slice("one", 1)`:  `slice: cannot mix incompatible types text and number[0] in slice`,
 		`min()`:            `min: at least 1 argument(s) expected but none found`,
 		`min("one")`:       `min: encountered non-numerical argument`,
 		`max()`:            `max: at least 1 argument(s) expected but none found`,

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -175,6 +175,17 @@ func (s *Zuite) TestRuntime_parseAndEvalExpr() {
 		`first_of(slice_bu)`:                   `false`,
 		`first_of(undefined,slice_nu)`:         `3`,
 		`first_of(undefined,slice_t,slice_nu)`: `"Alice"`,
+
+		// min
+		`min(1, 2, 3)`:              `1`,
+		`min(1, slice(2, 3), -4)`:   `-4`,
+		`min(slice(-1.008, -5.32))`: `-5.32`,
+
+		// max
+		`max(1, 2, 3)`:              `3`,
+		`max(1, slice(2, 3), -4)`:   `3`,
+		`max(slice(-1.008, -5.32))`: `-1.008`,
+		`max(1, 2, 3) round down 2`: `3.01`,
 	}
 	for input, output := range cases {
 		// fixture
@@ -207,24 +218,31 @@ func (s *Zuite) TestRuntime_parseAndEvalExpr() {
 		require.Equal(s.T(), "", p.next(), "%s should have reached eof", input)
 
 		actual, err := expr.compute(ws)
-		if assert.NoError(s.T(), err, input) {
-			assert.Equal(s.T(), expected, actual, "%s should equal %s was %s", input, output, actual)
+		if s.NoError(err, input) {
+			s.Equal(expected, actual, "%s should equal %s was %s", input, output, actual)
 		}
 	}
 }
 
 func (s *Zuite) TestRuntime_parseAndEvalExprExpectingFailure() {
 	cases := map[string]string{
-		`no_such_func()`: `unknown function no_such_func`,
-		`no.such.func()`: `unknown function no.such.func`,
-		`len(1, 2)`:      `len: 1 argument(s) expected but 2 found`,
-		`len(1)`:         `len: argument #1 expected to be text, or slice`,
-		`sum(1, 2)`:      `sum: 1 argument(s) expected but 2 found`,
-		`sum(1)`:         `sum: argument #1 expected to be slice of numbers`,
-		`sum(slice_t)`:   `sum: argument #1 expected to be slice of numbers`,
-		`if(1)`:          `if: at least 2 argument(s) expected but only 1 found`,
-		`if(1,2,3,4)`:    `if: at most 3 argument(s) expected but 4 found`,
-		`first_of()`:     `first_of: at least 1 argument(s) expected but none found`,
+		`no_such_func()`:   `unknown function no_such_func`,
+		`no.such.func()`:   `unknown function no.such.func`,
+		`len(1, 2)`:        `len: 1 argument(s) expected but 2 found`,
+		`len(1)`:           `len: argument #1 expected to be text, or slice`,
+		`sum(1, 2)`:        `sum: 1 argument(s) expected but 2 found`,
+		`sum(1)`:           `sum: argument #1 expected to be slice of numbers`,
+		`sum(slice_t)`:     `sum: argument #1 expected to be slice of numbers`,
+		`if(1)`:            `if: at least 2 argument(s) expected but only 1 found`,
+		`if(1,2,3,4)`:      `if: at most 3 argument(s) expected but 4 found`,
+		`first_of()`:       `first_of: at least 1 argument(s) expected but none found`,
+		`slice()`:          `slice: at least 1 argument(s) expected but none found`,
+		`slice(undefined)`: `slice: unable to infer slice type, only undefined values encountered`,
+		`slice(1, "one")`:  `slice: cannot mix incompatible types number[0] and text in slice`,
+		`min()`:            `min: at least 1 argument(s) expected but none found`,
+		`min("one")`:       `min: encountered non-numerical argument`,
+		`max()`:            `max: at least 1 argument(s) expected but none found`,
+		`max("one")`:       `max: encountered non-numerical argument`,
 	}
 	for input, output := range cases {
 		// fixture
@@ -239,5 +257,47 @@ func (s *Zuite) TestRuntime_parseAndEvalExprExpectingFailure() {
 
 		_, err = expr.compute(ws)
 		assert.EqualError(s.T(), err, output, input)
+	}
+}
+
+func (s *Zuite) TestRuntime_rSlice() {
+	cases := []struct {
+		args []Value
+		typ  Type
+	}{
+		// simple
+		{
+			args: []Value{NewNumberFromInt(6)},
+			typ:  &NumberType{0},
+		},
+		{
+			args: []Value{NewText("")},
+			typ:  &TextType{},
+		},
+		// slice of numbers takes largest scale
+		{
+			args: []Value{
+				NewNumberFromInt(6),
+				NewNumberFromInt(7).Round(ModeHalf, 1),
+			},
+			typ: &NumberType{1},
+		},
+		// with undefined, simply skip when doing type inference
+		{
+			args: []Value{NewText(""), vUndefined},
+			typ:  &TextType{},
+		},
+		{
+			args: []Value{vUndefined, NewText("")},
+			typ:  &TextType{},
+		},
+	}
+	for _, ex := range cases {
+		result, err := rSlice(newFnArgs(nil, ex.args))
+		if s.NoError(err) {
+			actual := result.(*Slice)
+			s.Equal(ex.args, actual.Elements(), "%v", ex.args)
+			s.Equal(ex.typ, actual.typ.elementType, "%v", ex.args)
+		}
 	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -142,6 +142,8 @@ func (s *Zuite) TestRuntime_parseAndEvalExpr() {
 		`len(text)`:      `5`,
 
 		// sum
+		`sum(1)`:        `1`,
+		`sum(1, 2)`:     `3`,
 		`sum(slice_n0)`: `10`,
 		`sum(slice_n2)`: `11.10`,
 		`sum(slice_nu)`: `undefined`,
@@ -185,7 +187,7 @@ func (s *Zuite) TestRuntime_parseAndEvalExpr() {
 		`max(1, 2, 3)`:              `3`,
 		`max(1, slice(2, 3), -4)`:   `3`,
 		`max(slice(-1.008, -5.32))`: `-1.008`,
-		`max(1, 2, 3) round down 2`: `3.01`,
+		`max(1, 2, 3) round down 2`: `3.00`,
 	}
 	for input, output := range cases {
 		// fixture
@@ -230,9 +232,9 @@ func (s *Zuite) TestRuntime_parseAndEvalExprExpectingFailure() {
 		`no.such.func()`:   `unknown function no.such.func`,
 		`len(1, 2)`:        `len: 1 argument(s) expected but 2 found`,
 		`len(1)`:           `len: argument #1 expected to be text, or slice`,
-		`sum(1, 2)`:        `sum: 1 argument(s) expected but 2 found`,
-		`sum(1)`:           `sum: argument #1 expected to be slice of numbers`,
-		`sum(slice_t)`:     `sum: argument #1 expected to be slice of numbers`,
+		`sum()`:            `sum: at least 1 argument(s) expected but none found`,
+		`sum("a")`:         `sum: encountered non-numerical argument`,
+		`sum(slice_t)`:     `sum: encountered non-numerical argument`,
 		`if(1)`:            `if: at least 2 argument(s) expected but only 1 found`,
 		`if(1,2,3,4)`:      `if: at most 3 argument(s) expected but 4 found`,
 		`first_of()`:       `first_of: at least 1 argument(s) expected but none found`,
@@ -247,6 +249,24 @@ func (s *Zuite) TestRuntime_parseAndEvalExprExpectingFailure() {
 	for input, output := range cases {
 		// fixture
 		ws := s.defs.MustNewWorksheet("all_types")
+		ws.MustSet("text", alice)
+		ws.MustAppend("slice_t", alice)
+		ws.MustAppend("slice_t", bob)
+		ws.MustAppend("slice_n0", NewNumberFromInt(2))
+		ws.MustAppend("slice_n0", NewNumberFromInt(3))
+		ws.MustAppend("slice_n0", NewNumberFromInt(5))
+		ws.MustAppend("slice_n2", NewNumberFromFloat64(2.22))
+		ws.MustAppend("slice_n2", NewNumberFromFloat64(3.33))
+		ws.MustAppend("slice_n2", NewNumberFromFloat64(5.55))
+		ws.MustAppend("slice_nu", NewUndefined())
+		ws.MustAppend("slice_nu", NewNumberFromInt(3))
+		ws.MustAppend("slice_nu", NewNumberFromInt(5))
+		ws.MustAppend("slice_b", NewBool(true))
+		ws.MustAppend("slice_b", NewBool(false))
+		ws.MustAppend("slice_b", NewBool(true))
+		ws.MustAppend("slice_bu", NewUndefined())
+		ws.MustAppend("slice_bu", NewBool(false))
+		ws.MustAppend("slice_bu", NewBool(true))
 
 		// test
 		p := newParser(strings.NewReader(input))

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -142,11 +142,12 @@ func (s *Zuite) TestRuntime_parseAndEvalExpr() {
 		`len(text)`:      `5`,
 
 		// sum
-		`sum(1)`:        `1`,
-		`sum(1, 2)`:     `3`,
-		`sum(slice_n0)`: `10`,
-		`sum(slice_n2)`: `11.10`,
-		`sum(slice_nu)`: `undefined`,
+		`sum(1)`:                   `1`,
+		`sum(1, 2.0, 3.00)`:        `6.00`,
+		`sum(slice(1, 2.0, 3.00))`: `6.00`,
+		`sum(slice_n0)`:            `10`,
+		`sum(slice_n2)`:            `11.10`,
+		`sum(slice_nu)`:            `undefined`,
 
 		// sumiftrue
 		`sumiftrue(slice_n0, slice_b)`:   `7`,

--- a/values.go
+++ b/values.go
@@ -480,6 +480,10 @@ func newSliceWithIdAndLastRank(typ *SliceType, id string, lastRank int, values .
 	return slice
 }
 
+func (slice *Slice) Len() int {
+	return len(slice.elements)
+}
+
 func (slice *Slice) Elements() []Value {
 	var values []Value
 	for _, element := range slice.elements {

--- a/values.go
+++ b/values.go
@@ -456,19 +456,28 @@ type Slice struct {
 	elements []sliceElement
 }
 
-func newSlice(typ *SliceType) *Slice {
-	return &Slice{
-		id:  uuid.Must(uuid.NewV4()).String(),
-		typ: typ,
-	}
+func newSlice(typ *SliceType, values ...Value) *Slice {
+	var (
+		id       = uuid.Must(uuid.NewV4()).String()
+		lastRank = 0
+	)
+	return newSliceWithIdAndLastRank(typ, id, lastRank, values...)
 }
 
-func newSliceWithIdAndLastRank(typ *SliceType, id string, lastRank int) *Slice {
-	return &Slice{
+func newSliceWithIdAndLastRank(typ *SliceType, id string, lastRank int, values ...Value) *Slice {
+	slice := &Slice{
 		id:       id,
 		typ:      typ,
 		lastRank: lastRank,
 	}
+	for _, value := range values {
+		var err error
+		slice, err = slice.doAppend(value)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return slice
 }
 
 func (slice *Slice) Elements() []Value {


### PR DESCRIPTION
tl;dr see `rFoldNumbers` and then how this generic helper is used to write `min`, `max`, `sum`. Adding a `slice` func to create slices inline, which helps with testing.

Adding helper `slice` to create slices, and adding `min` and `max` which works over a wide range of numerical arguments: trying to allow any possible ways in which numbers could be passed, list of numbers, slices of numbers, slices of slices of numbers, a combination of all of the above. For that, introducing a way to 'fold' numerical arguments which is a just a way to iterate over all numerical arguments in a generic way.

Changing `sum` to be based over the same scaffolding which `min` and `max` are based on.