### PR TITLE
Nicer errors in wstesting

### DIFF
--- a/tools/wstest.go
+++ b/tools/wstest.go
@@ -55,7 +55,7 @@ func runFeature(filename string) bool {
 	defer file.Close()
 
 	// read feature
-	scenarios, err := wstesting.ReadFeature(bufio.NewReader(file))
+	scenarios, err := wstesting.ReadFeature(bufio.NewReader(file), filename)
 	if err != nil {
 		fmt.Printf("%s\n", filename)
 		fmt.Printf("FAIL\t%s\n", err)

--- a/wstesting/wstesting_test.go
+++ b/wstesting/wstesting_test.go
@@ -454,7 +454,7 @@ Scenario: the_name_here_2
 		doc, err := gherkin.ParseGherkinDocument(strings.NewReader(ex.doc))
 		require.NoError(s.T(), err)
 
-		actual, err := docToScenarios(doc)
+		actual, err := docToScenarios(doc, "")
 		if assert.NoError(s.T(), err, ex.doc) {
 			for i := range actual {
 				assert.Len(s.T(), actual[i].steps, len(actual[i].commands))


### PR DESCRIPTION
Printing 'source:linenum:colnum: text: err' when errors are encountered.