### PR TITLE
Support for computing averages, with avg

### DIFF
--- a/expressions_test.go
+++ b/expressions_test.go
@@ -83,7 +83,7 @@ func (s *Zuite) TestSelectorSliceTypes() {
 }
 
 func (s *Zuite) TestFnArgs_newFromValues() {
-	args := newFnArgs(nil, []Value{vZero})
+	args := newFnArgs(nil, nil, []Value{vZero})
 	require.Equal(s.T(), 1, args.num())
 	require.True(s.T(), args.has(0))
 	require.False(s.T(), args.has(1))
@@ -93,7 +93,7 @@ func (s *Zuite) TestFnArgs_newFromValues() {
 }
 
 func (s *Zuite) TestFnArgs_checkArgsNum() {
-	args := newLazyFnArgs(nil, []expression{vZero})
+	args := newLazyFnArgs(nil, nil, []expression{vZero})
 
 	// before lazy eval
 	err := args.checkArgsNum(4)
@@ -107,7 +107,7 @@ func (s *Zuite) TestFnArgs_checkArgsNum() {
 }
 
 func (s *Zuite) TestFnArgs_get() {
-	args := newLazyFnArgs(nil, []expression{vZero})
+	args := newLazyFnArgs(nil, nil, []expression{vZero})
 	s.Len(args.exprs, 1)
 	s.NotNil(args.exprs[0])
 	s.Len(args.values, 1)

--- a/parser.go
+++ b/parser.go
@@ -414,7 +414,15 @@ func (p *parser) parseExpression(withOp bool) (expression, error) {
 					p.next()
 				}
 			}
-			first = &tCall{selector, args}
+			var round *tRound
+			if p.peek(pRound) {
+				var err error
+				round, err = p.parseRound()
+				if err != nil {
+					return nil, err
+				}
+			}
+			first = &tCall{selector, args, round}
 		}
 
 	case "paren":

--- a/parser_test.go
+++ b/parser_test.go
@@ -138,6 +138,7 @@ func (s *Zuite) TestParser_parseExpression() {
 		`len(something)`: &tCall{
 			tSelector([]string{"len"}),
 			[]expression{tSelector([]string{"something"})},
+			nil,
 		},
 		`first_of(undefined, 6, "Alice")`: &tCall{
 			tSelector([]string{"first_of"}),
@@ -146,9 +147,11 @@ func (s *Zuite) TestParser_parseExpression() {
 				&Number{6, &NumberType{0}},
 				&Text{"Alice"},
 			},
+			nil,
 		},
 		`foo.len()`: &tCall{
 			tSelector([]string{"foo", "len"}),
+			nil,
 			nil,
 		},
 		`sum(len(foo))`: &tCall{
@@ -159,8 +162,10 @@ func (s *Zuite) TestParser_parseExpression() {
 					[]expression{
 						tSelector([]string{"foo"}),
 					},
+					nil,
 				},
 			},
+			nil,
 		},
 		`sum(len(foo),8)`: &tCall{
 			tSelector([]string{"sum"}),
@@ -170,9 +175,11 @@ func (s *Zuite) TestParser_parseExpression() {
 					[]expression{
 						tSelector([]string{"foo"}),
 					},
+					nil,
 				},
 				&Number{8, &NumberType{0}},
 			},
+			nil,
 		},
 
 		// calls -- allow trailing comma
@@ -181,6 +188,7 @@ func (s *Zuite) TestParser_parseExpression() {
 			[]expression{
 				&Number{5, &NumberType{0}},
 			},
+			nil,
 		},
 		`first_of(1,2,3,)`: &tCall{
 			tSelector([]string{"first_of"}),
@@ -189,6 +197,7 @@ func (s *Zuite) TestParser_parseExpression() {
 				&Number{2, &NumberType{0}},
 				&Number{3, &NumberType{0}},
 			},
+			nil,
 		},
 		`sum(len(5,),)`: &tCall{
 			tSelector([]string{"sum"}),
@@ -198,8 +207,48 @@ func (s *Zuite) TestParser_parseExpression() {
 					[]expression{
 						&Number{5, &NumberType{0}},
 					},
+					nil,
 				},
 			},
+			nil,
+		},
+
+		// calls -- with rounding
+		`avg(7, 11) round half 4`: &tCall{
+			tSelector([]string{"avg"}),
+			[]expression{
+				&Number{7, &NumberType{0}},
+				&Number{11, &NumberType{0}},
+			},
+			&tRound{"half", 4},
+		},
+		`sum(1, avg(7, 11) round half 4) round up 7`: &tCall{
+			tSelector([]string{"sum"}),
+			[]expression{
+				&Number{1, &NumberType{0}},
+				&tCall{
+					tSelector([]string{"avg"}),
+					[]expression{
+						&Number{7, &NumberType{0}},
+						&Number{11, &NumberType{0}},
+					},
+					&tRound{"half", 4},
+				},
+			},
+			&tRound{"up", 7},
+		},
+		`avg(7, 11) round half 4 round up 7`: &tBinop{
+			opPlus,
+			&tCall{
+				tSelector([]string{"avg"}),
+				[]expression{
+					&Number{7, &NumberType{0}},
+					&Number{11, &NumberType{0}},
+				},
+				&tRound{"half", 4},
+			},
+			vZero,
+			&tRound{"up", 7},
 		},
 
 		// unop and binop

--- a/tree.go
+++ b/tree.go
@@ -129,6 +129,7 @@ type tReturn struct {
 
 // tCall represents a function invocation such as `len(some_slice)`.
 type tCall struct {
-	name tSelector
-	args []expression
+	name  tSelector
+	args  []expression
+	round *tRound
 }


### PR DESCRIPTION
Adding new function `avg`, which introduces some additional complexity: since an average can be calculated to a specific precision, and in the spirit of worksheets where precision and rounding must be explicitly provided, we need to have the ability to
  1. Pass a rounding mode to a functional call (practically, attach a `tRound` to a `tCall`)
  2. Allow the function implementation to decide whether a rounding mode is required or not

Doing this in a few steps:
- In the parser, explicitly looking for a parsing mode following a function call, and directly attaching this to the `tCall` node
- In the `compute` of `tCall`, implementing rounding to preserve the functionality we had before
- Extending `fnArgs` to also have a rounding mode, such that individual functions can choose to do something with the rounding mode explicitely

While this works, this is pretty mediocre: rounding code is now in multiple places (in `compute` of `tBinop` and `tCall`), we round averages even though the rounding is already handled in the final division, some similarly wrong expressions have differing error messages. A more "pure" treatment seems like it'd require quite a bit of re-work, and re-shuffling, which doesn't feel worthwhile now. (And this re-work could likely handle the other complex rounding cases left un-implemented.)