### PR TITLE
Optimizing how slice references are recorded

### DIFF
--- a/dbstore.go
+++ b/dbstore.go
@@ -606,7 +606,7 @@ func (p *persister) update(ws *Worksheet) error {
 		adoptedChildren       = make(map[int][]string)
 	)
 	for index, change := range diff {
-		valuesToUpdate = append(valuesToUpdate, index)
+		shouldUpdateValueRecord := true
 
 		// non-slice values
 		if _, ok := change.before.(*Slice); !ok {
@@ -631,6 +631,8 @@ func (p *persister) update(ws *Worksheet) error {
 				panic(fmt.Sprintf("unexpected: before=%s, after%s", change.before, change.after))
 			}
 			if sliceBefore.id == sliceAfter.id {
+				shouldUpdateValueRecord = sliceBefore.lastRank != sliceAfter.lastRank
+
 				sliceChange := diffSlices(sliceBefore, sliceAfter)
 
 				sliceId := sliceBefore.id
@@ -651,6 +653,9 @@ func (p *persister) update(ws *Worksheet) error {
 					}
 				}
 			}
+		}
+		if shouldUpdateValueRecord {
+			valuesToUpdate = append(valuesToUpdate, index)
 		}
 	}
 

--- a/slices_test.go
+++ b/slices_test.go
@@ -372,13 +372,6 @@ func (s *Zuite) TestSliceUpdate_appendsThenDelThenAppendAgain() {
 			WorksheetId: wsId,
 			Index:       42,
 			FromVersion: 1,
-			ToVersion:   1,
-			Value:       fmt.Sprintf(`[:2:%s`, theSliceId),
-		},
-		{
-			WorksheetId: wsId,
-			Index:       42,
-			FromVersion: 2,
 			ToVersion:   2,
 			Value:       fmt.Sprintf(`[:2:%s`, theSliceId),
 		},


### PR DESCRIPTION
When slices are modified, yet preserve their id and last rank, we do not need to update the value record, only the slice elements.